### PR TITLE
BUG FIX: Deny user access if changed status

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -260,7 +260,9 @@ class PMPro_Approvals {
 			if(PMPro_Approvals::isApproved($user->ID, $level->id)) {
 				$access = true;
 				break;
-			}
+			}else{
+				$access = false;
+				break;
 		}
 		
 		return $access;


### PR DESCRIPTION
If the user has been approved and then reset to pending or denied, deny access.