### PR TITLE
Membership shortcode fix

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -422,8 +422,10 @@ class PMPro_Approvals {
 		if(empty($user_id))
 			return $haslevel;
 		
-		//no levels, skip
-		if(empty($levels))
+		$level = pmpro_getMembershipLevelForUser( $user_id );
+
+		//If no levels but user is approved, return true.
+		if( empty( $levels ) && PMPro_Approvals::isApproved( $user_id, $level->ID ) ) 
 			return $haslevel;
 		
 		//now we need to check if the user is approved for ANY of the $levels


### PR DESCRIPTION
If a page/post had no membership levels set but had shortcode within
the content, this content would be visible.

If levels are empty and the user is approved return true.