### PR TITLE
Add Filter to Approval Status text

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -582,6 +582,8 @@ class PMPro_Approvals {
 
 		}
 
+		$status = apply_filters( 'pmpro_approvals_status_filter', $status, $user_id, $level_id );
+
 		return $status;
 	}
 	
@@ -735,8 +737,8 @@ class PMPro_Approvals {
 			
 		$sqlQuery .= "LIMIT $start, $limit";	
 						
-		$theusers = $wpdb->get_results($sqlQuery);		
-		
+		$theusers = $wpdb->get_results($sqlQuery);	
+
 		return $theusers;		
 	}
 	


### PR DESCRIPTION
This adds a filter to the approval status text. This is useful for other plugins to hook into (such as email confirmation add on) and change the message from "Approved" to "Waiting for Email Confirmation".

This does not affect the approved, pending or denied status but simply changes the wording.