### PR TITLE
Update pmpro-approvals.php

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -140,7 +140,15 @@ class PMPro_Approvals {
     public static function admin_menu(){
     	global $menu, $submenu;
 
+    	if ( ! defined( 'PMPRO_VERSION' ) ) {
+        	return;
+    	}
+    
+    	if (version_compare( PMPRO_VERSION, '2.0' ) >= 0 ) {
+		add_submenu_page( 'pmpro-dashboard', __( 'Approvals', 'pmpro-approvals' ), __( 'Approvals', 'pmpro-approvals' ), 'pmpro_approvals', 'pmpro-approvals', array( 'PMPro_Approvals', 'admin_page_approvals' ) );
+    	} else {
 		add_submenu_page( 'pmpro-membershiplevels', __( 'Approvals', 'pmpro-approvals' ), __( 'Approvals', 'pmpro-approvals' ), 'pmpro_approvals', 'pmpro-approvals', array( 'PMPro_Approvals', 'admin_page_approvals' ) );
+    	}
 
 		$user_count = PMPro_Approvals::getApprovalCount();
 


### PR DESCRIPTION
The old dashboard link pointed to pmpro-membershiplevels as its parent. This resulted in the link breaking and pointing to http://www.site.com/wp-admin/pmpro-approvals instead of http://www.site.com/wp-admin/admin.php?page=pmpro-approvals leading to a 404.