### PR TITLE
Bug Fix: Admin email details were incorrect.

### DIFF
--- a/classes/class.approvalemails.php
+++ b/classes/class.approvalemails.php
@@ -95,8 +95,7 @@ class PMPro_Approvals_Email extends PMProEmail {
 	public function sendAdminPending( $member = null, $admin = null ) {
 
 		if ( empty( $admin ) ) {
-			global $current_user;
-			$admin = $current_user;
+			$admin = get_user_by( 'email', get_option( 'admin_email' ) );
 		} elseif ( is_int( $admin ) ) {
 			$admin = get_user_by( 'ID', $admin );
 		}
@@ -146,8 +145,7 @@ class PMPro_Approvals_Email extends PMProEmail {
 	public function sendAdminApproval( $member = null, $admin = null ) {
 
 		if ( empty( $admin ) ) {
-			global $current_user;
-			$admin = $current_user;
+			$admin = get_user_by( 'email', get_option( 'admin_email' ) );
 		} elseif ( is_int( $admin ) ) {
 			$admin = get_user_by( 'ID', $admin );
 		}
@@ -198,8 +196,7 @@ class PMPro_Approvals_Email extends PMProEmail {
 	public function sendAdminDenied( $member = null, $admin = null ) {
 
 		if ( empty( $admin ) ) {
-			global $current_user;
-			$admin = $current_user;
+			$admin = get_user_by( 'email', get_option( 'admin_email' ) );
 		} elseif ( is_int( $admin ) ) {
 			$admin = get_user_by( 'ID', $admin );
 		}


### PR DESCRIPTION
In some cases the admin details would be set to the user's instead.

This forces to use the admin email address in the "Settings" > "General" area.