### PR TITLE
Bug Fix: Property of undefined

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -585,7 +585,11 @@ class PMPro_Approvals {
 		//get the PMPro level for the user
 		if ( empty( $level_id ) ) {
 			$level    = pmpro_getMembershipLevelForUser( $user_id );
-			$level_id = $level->ID;
+			
+			if ( ! empty( $level ) ) {
+				$level_id = $level->ID;
+			}
+			
 		} else {
 			$level = pmpro_getLevel( $level_id );
 		}


### PR DESCRIPTION
Bug Fix: If a user didn't have a membership level it would still try to get the level object from the approvals screen.