### PR TITLE
Change "Your Level" to a different status

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -102,6 +102,7 @@ class PMPro_Approvals {
 
 		//Integrate with Member Directory.
 		add_filter( 'pmpro_member_directory_sql_parts', array( 'PMPro_Approvals', 'pmpro_member_directory_sql_parts'), 10, 9 );
+		add_filter( 'gettext', array( 'PMPro_Approvals', 'change_your_level_text' ), 10, 3 );
 		//plugin row meta
 		add_filter( 'plugin_row_meta', array( 'PMPro_Approvals', 'plugin_row_meta' ), 10, 2 );
 	}
@@ -1475,6 +1476,35 @@ style="display: none;"<?php } ?>>
 
 		load_plugin_textdomain( 'pmpro-approvals', false, basename( dirname( __FILE__ ) ) . '/languages' );
 	}
+
+	/**
+	 * Change "Your Level" to "Awaiting Approval" in these instances for pending users. 
+	 * @since 1.3
+	 */
+	public static function change_your_level_text( $translated_text, $text, $domain ) {
+		global $current_user;
+
+		$approved = self::isApproved( $current_user->ID );
+
+		// Bail if the user is approved.
+		if ( $approved ) {
+			return $translated_text;
+		}
+
+		$approval = self::getUserApproval( $current_user->ID );
+
+		if ( $domain == 'paid-memberships-pro' ) {
+			if ( $translated_text == 'Your&nbsp;Level' ) {
+				if ( $approval['status'] == 'pending' ){
+					$translated_text = __( 'Pending Approval', 'pmpro-approvals' );
+				} else {
+					$translated_text = __( 'Membership Denied', 'pmpro-approvals' );
+				}
+			}
+		}
+		return $translated_text;
+	}
+
 
 } // end class
 


### PR DESCRIPTION
Change your level to a different status.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adjusts the "Your Level" text if the user is pending or denied.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Issue: https://github.com/strangerstudios/pmpro-approvals/issues/53.

### How to test the changes in this Pull Request:

1. Sign up for a level which requires approval. Do not approve this user.
2. View levels page. Your level should change to "Pending Approval".
3. Deny the user. Go back to levels page, Your level should change to "Membership Denied".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Enhancement: Change "Your Level" text on levels page, and all instances to "Pending Approval" or "Memberships Denied" if not approved. 