### PR TITLE
Bug Fixes + Version Bump

### DIFF
--- a/adminpages/userinfo.php
+++ b/adminpages/userinfo.php
@@ -75,7 +75,7 @@ if ( empty( $_REQUEST['user_id'] ) ) {
 				if ( ! PMPro_Approvals::getEmailConfirmation( $user->ID ) ) {
 					_e( 'Email Confirmation Required.', 'pmpro-approvals' );
 				} else {
-					echo esc_html( PMPro_Approvals::getUserApprovalStatus( $user->ID, null, false ) );
+					echo PMPro_Approvals::getUserApprovalStatus( $user->ID, null, false );
 				?>
 				[<a href="javascript:askfirst('Are you sure you want to reset approval for <?php echo esc_attr( $user->user_login ); ?>?', '?page=pmpro-approvals&user_id=<?php echo $user->ID; ?>&unapprove=<?php echo $user->ID; ?>');">X</a>]
 				<?php

--- a/classes/class.approvalemails.php
+++ b/classes/class.approvalemails.php
@@ -185,7 +185,7 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$this->data['membership_level_name'] = $level->name;
 			$this->data['member_email']          = $member->user_email;
 			$this->data['member_name']           = $member->display_name;
-			$this->data['view_profile']          = admin_url( 'admin.php/?page=pmpro-approvals&user_id=' . $member->ID );
+			$this->data['view_profile']          = admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $member->ID );
 		}
 
 		$this->data = apply_filters( 'pmpro_approvals_admin_approved_email_data', $this->data, $member, $admin );
@@ -237,7 +237,7 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$this->data['membership_level_name'] = $level->name;
 			$this->data['member_email']          = $member->user_email;
 			$this->data['member_name']           = $member->display_name;
-			$this->data['view_profile']          = admin_url( 'admin.php/?page=pmpro-approvals&user_id=' . $member->ID );
+			$this->data['view_profile']          = admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $member->ID );
 		}
 
 		$this->data = apply_filters( 'pmpro_approvals_admin_denied_email_data', $this->data, $member, $admin );

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -3,7 +3,7 @@
 Plugin Name: Paid Memberships Pro - Approvals Add On
 Plugin URI: https://www.paidmembershipspro.com/add-ons/approval-process-membership/
 Description: Grants administrators the ability to approve/deny memberships after signup.
-Version: 1.2
+Version: 1.3
 Author: Stranger Studios
 Author URI: https://www.paidmembershipspro.com
 Text Domain: pmpro-approvals
@@ -1075,7 +1075,7 @@ class PMPro_Approvals {
 
 			// Only show this if the user has an approval status.
 			if ( $level_approval ) {
-			  printf( '<li><strong>' . __( 'Status:') . '</strong> %s</li>', 'pmpro-approvals', $approval_status );
+			  printf( '<li><strong>' . __( 'Status', 'pmpro-approvals' ) . ':' . '</strong> %s</li>', $approval_status );
 			}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,17 @@ Members pending approval will not have access to view members-only content until
 View full documentation at: https://www.paidmembershipspro.com/add-ons/approval-process-membership/
 
 == Changelog ==
+= 1.3 - 2019-07-23 =
+* BUG FIX: Remove "Status" from account page if the user's level doesn't require approval.
+* BUG FIX: Approval link being escaped in Paid Memberships Pro 2.x+ 'recent' members dashboard widget.
+* BUG FIX/ENHANCEMENT: Improved custom fields not showing for pending members edit page and view info pages.
+* BUG FIX/ENHANCEMENT: Integrate with Email Confirmation Add On. Improved UX.
+* ENHANCEMENT: Improved i18n. Some strings were missing. Please submit a PR to get your locale included in a future release.
+* ENHANCEMENT: Integrate with Member Directory Add On. Automatically hide non-approved users from Member Directory Add On pages. Member Directory .5.4+ required.
+* ENHANCEMENT: Hooks added in for Approvals table to allow inserting custom columns ("pmpro_approvals_list_extra_cols_header" and "pmpro_approvals_list_extra_cols_body" respectively).
+* SECURITY: General security updates when outputting data to the screen.
+
+
 = 1.2 - 2019-03-20 =
 * BUG FIX: Fixed issue with [membership] shortcode not working correctly for pending/logged-in non-members.
 * BUG FIX: Fixed integration with Email Confirmation. Admins will only be able to approve/deny users once their emails are confirmed.


### PR DESCRIPTION
Bug Fix: Email URLs for some email templates were 404.

Minor bug fix in i18n for account bullet top.

Bug Fix: URL for the 'who' approved was being escaped in the view profile for Approvals "View Info" page.

Version bump + readme adjustment.

### All Submissions:

* [ ] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Issue: XXX.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.