### PR TITLE
Allow users to update profile fields

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -468,11 +468,16 @@ class PMPro_Approvals {
 			return $haslevel;
 		}
 
-		// Ignore if on the edit user screen. This will allow admins/users to update custom fields.
-		$current_screen = get_current_screen();
-		
-		if ( $current_screen->base == 'user-edit' || $current_screen->base == 'profile' ) {
-			return $haslevel;
+		// Only check this inside admin of WordPress.
+		if ( is_admin() ) {
+
+			// Ignore if on the edit user screen. This will allow admins/users to update custom fields.
+			$current_screen = get_current_screen();
+			
+			if ( $current_screen->base == 'user-edit' || $current_screen->base == 'profile' ) {
+				return $haslevel;
+			}
+
 		}
 
 		//no user, skip

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -468,6 +468,13 @@ class PMPro_Approvals {
 			return $haslevel;
 		}
 
+		// Ignore if on the edit user screen. This will allow admins/users to update custom fields.
+		$current_screen = get_current_screen();
+		
+		if ( $current_screen->base == 'user-edit' || $current_screen->base == 'profile' ) {
+			return $haslevel;
+		}
+
 		//no user, skip
 		if ( empty( $user_id ) ) {
 			return $haslevel;


### PR DESCRIPTION
Allow user's to update their custom fields if not-approved in the edit user profile page.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Issue: N/A

### How to test the changes in this Pull Request:

1. Edit a non-approved user which has custom fields from Register Helper.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

* Bug Fix: Custom fields not showing up on edit user profile page for non-approved members.