### PR TITLE
Fix for get_current_screen undefined error

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -469,7 +469,7 @@ class PMPro_Approvals {
 		}
 
 		// Only check this inside admin of WordPress.
-		if ( is_admin() && defined( "get_current_screen" ) ) {
+		if ( is_admin() && function_exists( "get_current_screen" ) ) {
 
 			// Ignore if on the edit user screen. This will allow admins/users to update custom fields.
 			$current_screen = get_current_screen();

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -469,7 +469,7 @@ class PMPro_Approvals {
 		}
 
 		// Only check this inside admin of WordPress.
-		if ( is_admin() ) {
+		if ( is_admin() && defined( "get_current_screen" ) ) {
 
 			// Ignore if on the edit user screen. This will allow admins/users to update custom fields.
 			$current_screen = get_current_screen();


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In PMPro_Approvals::pmpro_has_membership_level(), we check for is_admin() before calling get_current_screen(). However, "there are cases where is_admin() will return true, but attempting to call get_current_screen() will result in a fatal error because it is not defined. One known example is wp-admin/customize.php." (from the WP Codex: https://codex.wordpress.org/Function_Reference/get_current_screen) Updating to also check if get_current_screen() is defined to avoid fatal errors.

Forum ticket (mods only): 
https://www.paidmembershipspro.com/forums/topic/aprovals/

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Checking if 'get_current_screen' is defined to prevent errors when checking membership access from admin.