### PR TITLE
fix for member directory integration SQL

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -1458,7 +1458,8 @@ style="display: none;"<?php } ?>>
 	 * @since 1.3
 	 */
 	public static function pmpro_member_directory_sql_parts( $sql_parts, $levels, $s, $pn, $limit, $start, $end, $order_by, $order ) {
-		$sql_parts['JOIN'] .= "LEFT JOIN wp_usermeta umm
+		global $wpdb;
+		$sql_parts['JOIN'] .= "LEFT JOIN " . $wpdb->prefix . "usermeta umm
 		ON umm.meta_key = CONCAT('pmpro_approval_', mu.membership_id)
 		  AND umm.meta_key != 'pmpro_approval_log'
 		  AND u.ID = umm.user_id ";


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The `PMPro_Approvals::pmpro_member_directory_sql_parts()` function wasn't accounting for non-default table prefixes, so it was causing errors in the member directory SQL and members wouldn't be shown on the Directory page.

### How to test the changes in this Pull Request:

1. Use a site with a non-standard table prefix (something other than `wp_`); if you don't have one and are using a VM, spinning up a new site would probably be the easiest way (I provisioned one using VVV)
2. Install current version of PMPro Approvals + Member Directory
3. Go to Directory page
4. Get a SQL error in log, no members displayed in directory
5. Update PMPro Approvals with this version
6. Repeat steps 1-3, directory displayed correctly, error from step 4 gone

Forum ticket (mods only):
https://www.paidmembershipspro.com/forums/topic/member-directory-not-working/

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

### Changelog entry

> BUGFIX: Fixed issue in integration with Member Directory and Profiles Add On that could cause directories to not display an users if the table prefix isn't set to default.