### PR TITLE
Add filter to requiresApproval

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -271,7 +271,10 @@ class PMPro_Approvals {
 		}
 
 		$options = self::getOptions( $level_id );
-		return $options['requires_approval'];
+		
+		$requires_approval = apply_filters( 'pmpro_approvals_level_requires_approval', $options['requires_approval'], $level_id);
+		
+		return $requires_approval;
 	}
 
 	/**


### PR DESCRIPTION
Add filter to requiresApproval to allow it to be modified on an ad hoc basis (e.g., in certain renewal situations). Unfiltered (stock) code flow is unchanged.
