### PR TITLE
Fix hardcoded database prefix

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -1458,7 +1458,8 @@ style="display: none;"<?php } ?>>
 	 * @since 1.3
 	 */
 	public static function pmpro_member_directory_sql_parts( $sql_parts, $levels, $s, $pn, $limit, $start, $end, $order_by, $order ) {
-		$sql_parts['JOIN'] .= "LEFT JOIN wp_usermeta umm
+		global $wpdb;
+		$sql_parts['JOIN'] .= "LEFT JOIN {$wpdb->usermeta} umm
 		ON umm.meta_key = CONCAT('pmpro_approval_', mu.membership_id)
 		  AND umm.meta_key != 'pmpro_approval_log'
 		  AND u.ID = umm.user_id ";


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Issue: XXX.

### How to test the changes in this Pull Request:

1. Activate pmpro-approvals
2. Activate pmpro-member-directory
3. Change database prefix to anything but wp_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

There is a problem with WP installations that use a different DB prefix and the LEFT JOIN had the default wp_ prefix and the JOIN didn't run correctly.