### PR TITLE
Fixing a notice for check payment instructions confirmation message text when approval level is free

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -1154,7 +1154,7 @@ class PMPro_Approvals {
 		$confirmation_message = '<p>' . sprintf( __( 'Thank you for your membership to %1$s. Your %2$s membership status is: <b>%3$s</b>.', 'pmpro-approvals' ), get_bloginfo( 'name' ), $current_user->membership_level->name, $approval_status ) . '</p>';
 
 		// Check instructions
-		if ( $pmpro_invoice->gateway == "check" && ! pmpro_isLevelFree( $pmpro_invoice->membership_level ) ) {
+		if ( ! empty( $pmpro_invoice ) && $pmpro_invoice->gateway == "check" && ! pmpro_isLevelFree( $pmpro_invoice->membership_level ) ) {
 			$confirmation_message .= '<div class="pmpro_payment_instructions">' . wpautop( wp_unslash( pmpro_getOption("instructions") ) ) . '</div>';
 		}
 


### PR DESCRIPTION
There was an issue in the previous PR for the check payment instructions - a warning when the level is free because the $pmpro_order object is "FALSE" in this case.

This PR checks that the $pmpro_order object is not empty on the confirmation page.