### PR TITLE
PHP Notice Fixed

### DIFF
--- a/classes/class.approvalemails.php
+++ b/classes/class.approvalemails.php
@@ -113,8 +113,8 @@ class PMPro_Approvals_Email extends PMProEmail {
 		$this->body     = file_get_contents( PMPRO_APP_DIR . '/email/admin_notification.html' );
 		$this->data     = array(
 			'subject'               => $this->subject,
-			'name'                  => $admin->display_name,
-			'user_login'            => $admin->user_login,
+			'name'                  => isset( $admin->display_name ) ? $admin->display_name : "",
+			'user_login'            => isset( $admin->user_login ) ? $admin->user_login : "",
 			'sitename'              => get_option( 'blogname' ),
 			'siteemail'             => pmpro_getOption( 'from_email' ),
 			'login_link'            => wp_login_url(),


### PR DESCRIPTION
#113 Trying to get property of non-object when emails are sent - Fixed

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Issue: #113.

### How to test the changes in this Pull Request:

1. Set the site's email notification address to an email address that doesn't match any users.
2. The plugin will then try and get a user by that email. Returns false. Notices are thrown. 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.