### PR TITLE
Ensuring approvals load only after all plugins have loaded to prevent…

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -12,7 +12,13 @@ Domain Path: /languages
 
 define( 'PMPRO_APP_DIR', dirname( __FILE__ ) );
 
-require PMPRO_APP_DIR . '/classes/class.approvalemails.php';
+/**
+ * Only load approvals after plugins have been loaded. Otherwise it may be loaded too early (e.g., before PMPro).
+ */
+function pmpro_approvals_plugins_loaded() {
+	require PMPRO_APP_DIR . '/classes/class.approvalemails.php';
+}
+add_action( 'plugins_loaded', 'pmpro_approvals_plugins_loaded' );
 
 class PMPro_Approvals {
 	/*


### PR DESCRIPTION
This PR resolves an issue with multisite and membership approvals with the plugin loading too early.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Prevents plugin from loading too early causing WSOD when a member checks out.

Closes Issue: XXX.

### How to test the changes in this Pull Request:

![wsod](https://user-images.githubusercontent.com/636521/76783159-59018200-677f-11ea-94bb-917cd1839b85.gif)

1. Use multisite and the approvals add on.
2. Try to check out as a user.
3. See WSOD

![pr-fix](https://user-images.githubusercontent.com/636521/76783175-63238080-677f-11ea-9094-63002c562bd1.gif)


### Other information:

* [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Better Multisite compatibility. 