### PR TITLE
Check custom registration field level before displaying on user info page

### DIFF
--- a/adminpages/userinfo.php
+++ b/adminpages/userinfo.php
@@ -93,7 +93,7 @@ if ( empty( $_REQUEST['user_id'] ) ) {
 	</table>
 	
 	<?php
-		if ( function_exists( 'pmprorh_getProfileFields' ) ) {
+		if ( function_exists( 'pmprorh_getProfileFields' ) && function_exists( 'pmprorh_checkFieldForLevel' ) ) {
 			global $pmprorh_registration_fields, $pmprorh_checkout_boxes;
 
 			//show the fields
@@ -108,7 +108,7 @@ if ( empty( $_REQUEST['user_id'] ) ) {
 					//cycle through groups
 					foreach ( $fields as $field ) {
 						// show field as long as it's not false
-						if ( false != $field->profile ) {
+						if ( false != $field->profile && pmprorh_checkFieldForLevel( $field, 'profile', $user->ID ) ) {
 						?>
 						<tr>
 							<th><label><?php echo esc_attr( $field->label ); ?></label></th>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Add On will now check a field's level before displaying it on the user info page.

Closes Issue: #125.

### How to test the changes in this Pull Request:

1. Create multiple fields that are for specific levels, for example, a phone field that for level 1 shows on profile only and on checkout shows for level 3.
2. Signup for level 3 that requires approval.
3. As an admin, navigate to the approvals page and view the user's information.
4. This will show the phone field once

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Check custom registration field level before displaying on user profile.