### PR TITLE
Add support for Pay By Check Add On

### DIFF
--- a/classes/class.paybycheck.php
+++ b/classes/class.paybycheck.php
@@ -1,0 +1,128 @@
+<?php
+
+class PMPro_Approvals_Check {
+
+	/**
+	 * The gateway ID for Pay By Check.
+	 *
+	 * @var string
+	 */
+	const PAY_BY_CHECK = 'check';
+
+	/**
+	 * The status value for a pending order.
+	 *
+	 * @var string
+	 */
+	const PENDING_STATUS = 'pending';
+
+	/**
+	 * The status value of a successful order
+	 *
+	 * @var string
+	 */
+	const SUCCESS_STATUS = 'success';
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var \PMPro_Approvals_Check
+	 */
+	private static $instance = null;
+
+	/**
+	 * Creates or returns an instance of this class.
+	 *
+	 * @return  PMPro_Approvals_Check A single instance of this class.
+	 */
+	public static function get_instance() {
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new PMPro_Approvals_Check();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Create a new class instance.
+	 *
+	 * @return void
+	 */
+	private function __construct() {
+		add_action( 'init', array( static::class, 'init' ) );
+	}
+
+	/**
+	 * Initialise actions and filters
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		// bail if PMPro is not loaded
+		if ( ! defined( 'PMPRO_VERSION' ) ) {
+			return;
+		}
+
+		add_action( 'pmpro_approvals_after_approve_member', array( static::class, 'pmpro_approvals_after_approve_member' ), 10, 2 );
+		add_action( 'pmpro_update_order', array( static::class, 'pmpro_update_order' ), 10, 2 );
+	}
+
+	/**
+	 * Handle pmpro_approvals_after_approve_member hook
+	 *
+	 * @param  int $user_id  User ID of the member who was approved
+	 * @param  int $level_id Level ID for the member that was approved
+	 * @return void
+	 */
+	public static function pmpro_approvals_after_approve_member($user_id, $level_id) {
+		// get the user's most recent order for the level and gateway
+		$lastorder = new MemberOrder();
+		$lastorder->getLastMemberOrder( $user_id, null, $level_id, self::PAY_BY_CHECK );
+
+		if ( empty( $lastorder ) ) {
+			return;
+		}
+
+		// ignore if the order status is anything besides pending
+		if ( $lastorder->status !== self::PENDING_STATUS ) {
+			return;
+		}
+
+		// mark the order as successful and save
+		$lastorder->status = self::SUCCESS_STATUS;
+		$lastorder->saveOrder();
+	}
+
+	/**
+	 * Handle pmpro_update_order hook
+	 *
+	 * @param  \MemberOrder $order Order that is about to be updated
+	 * @return \MemberOrder
+	 */
+	public static function pmpro_update_order($order) {
+		$previous_order = new MemberOrder();
+		$previous_order->getMemberOrderByID( $order->id );
+
+		// bail if we are not transitioning from pending to success on a check order
+		if ( ! ( $previous_order->status === 'pending' && $order->status === 'success' && $order->gateway === 'check' ) ) {
+			return $order;
+		}
+
+		$membership_level = $previous_order->getMembershipLevel();
+		// bail if the user has no pending approval for the membership level
+		if ( ! PMPro_Approvals::isPending( $order->user_id, $membership_level->id ) ) {
+			return $order;
+		}
+
+		// temporarily remove hook to prevent a race condition
+		remove_action( 'pmpro_approvals_after_approve_member', array( static::class, 'pmpro_approvals_after_approve_member' ), 10, 2 );
+		// approve the member
+		PMPro_Approvals::approveMember( $order->user_id, $membership_level->id );
+		// restore hook
+		add_action( 'pmpro_approvals_after_approve_member', array( static::class, 'pmpro_approvals_after_approve_member' ), 10, 2 );
+		return $order;
+	}
+
+}
+
+PMPro_Approvals_Check::get_instance();

--- a/classes/class.paybycheck.php
+++ b/classes/class.paybycheck.php
@@ -88,6 +88,15 @@ class PMPro_Approvals_Check {
 			return;
 		}
 
+		$membership_level_options = PMPro_Approvals::getOptions( $level_id );
+		if ( empty ( $membership_level_options['approve_check_automatically'] ) ) {
+			return;
+		}
+		$approve_check_automatically = $membership_level_options['approve_check_automatically'];
+		if ( $approve_check_automatically !== 1) {
+			return;
+		}
+
 		// mark the order as successful and save
 		$lastorder->status = self::SUCCESS_STATUS;
 		$lastorder->saveOrder();
@@ -111,6 +120,15 @@ class PMPro_Approvals_Check {
 		$membership_level = $previous_order->getMembershipLevel();
 		// bail if the user has no pending approval for the membership level
 		if ( ! PMPro_Approvals::isPending( $order->user_id, $membership_level->id ) ) {
+			return $order;
+		}
+
+		$membership_level_options = PMPro_Approvals::getOptions( $membership_level->id );
+		if ( empty ( $membership_level_options['approve_check_automatically'] ) ) {
+			return $order;
+		}
+		$approve_check_automatically = $membership_level_options['approve_check_automatically'];
+		if ( $approve_check_automatically !== 1 ) {
 			return $order;
 		}
 

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -17,6 +17,7 @@ define( 'PMPRO_APP_DIR', dirname( __FILE__ ) );
  */
 function pmpro_approvals_plugins_loaded() {
 	require PMPRO_APP_DIR . '/classes/class.approvalemails.php';
+	require PMPRO_APP_DIR . '/classes/class.paybycheck.php';
 }
 add_action( 'plugins_loaded', 'pmpro_approvals_plugins_loaded' );
 

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -244,6 +244,7 @@ class PMPro_Approvals {
 				$r = array(
 					'requires_approval' => 0,
 					'restrict_checkout' => 0,
+					'approve_check_automatically' => 0,
 				);
 			}
 		} else {
@@ -297,7 +298,13 @@ class PMPro_Approvals {
 			$options = array(
 				'requires_approval' => false,
 				'restrict_checkout' => false,
+				'approve_check_automatically' => false
 			);
+		}
+
+		$approve_check_automatically = 0;
+		if ( ! empty ( $options['approve_check_automatically'] ) ) {
+			$approve_check_automatically = $options['approve_check_automatically'];
 		}
 
 		//figure out approval_setting from the actual options
@@ -352,6 +359,33 @@ class PMPro_Approvals {
 					?>
 				</td>
 			</tr>
+			<tr style="display: none;">
+				<th scope="row" valign="top"><label for="approval_approve_check_automatically"><?php _e( 'Approve check payments automatically?', 'pmpro-approvals' ); ?></label></th>
+				<td>
+					<select id="approval_approve_check_automatically" name="approval_approve_check_automatically">
+						<option value="0" <?php selected( $approve_check_automatically, 0 ); ?>><?php _e( 'No', 'pmpro-approvals' ); ?></option>
+						<option value="1" <?php selected( $approve_check_automatically, 1 ); ?>><?php _e( 'Yes', 'pmpro-approvals' ); ?></option>
+					</select>
+					<br />
+					<small>
+						<?php
+							_e(
+								'Pending members will be approved automatically whenever you change the status of their check payment order to success.',
+								'pmpro-approvals'
+							);
+						?>
+					</small>
+					<br />
+					<small>
+					<?php
+							_e(
+								'	Additionally, their check payments will be marked successful when you approve them.',
+								'pmpro-approvals'
+							);
+						?>
+					</small>
+				</td>
+			</tr>
 			<?php } ?>
 		</tbody>
 		</table>
@@ -364,12 +398,22 @@ class PMPro_Approvals {
 					else
 						jQuery('#approval_restrict_level').closest('tr').hide();
 				}
+
+				function pmproap_toggleCheckPaymentApproval() {
+					if (jQuery('#approval_setting').val() > 0) {
+						jQuery('#approval_approve_check_automatically').closest('tr').show();
+						return;
+					}
+					jQuery('#approval_approve_check_automatically').closest('tr').hide();
+				}
 				
 				//bind to approval setting change
 				jQuery('#approval_setting').change(function() { pmproap_toggleWhichLevel(); });
+				jQuery('#approval_setting').change(function() { pmproap_toggleCheckPaymentApproval(); });
 				
 				//run on load
 				pmproap_toggleWhichLevel();
+				pmproap_toggleCheckPaymentApproval();
 			});
 		</script>
 		<?php } ?>
@@ -420,9 +464,16 @@ class PMPro_Approvals {
 			$options[ $level_id ] = array();
 		}
 
+		if ( ! empty( $_REQUEST['approval_approve_check_automatically'] ) ) {
+			$approve_check_automatically = intval( $_REQUEST['approval_approve_check_automatically'] );
+		} else {
+			$approve_check_automatically = 0;
+		}
+
 		//update options
 		$options[ $level_id ]['requires_approval'] = $requires_approval;
 		$options[ $level_id ]['restrict_checkout'] = $restrict_checkout;
+		$options[ $level_id ]['approve_check_automatically'] = $approve_check_automatically;
 
 		//save it
 		self::saveOptions( $options );


### PR DESCRIPTION
Closes #46

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

If a user is approved via the Approvals Add On, their Pay By Check order status will be changed to  'success'

If a user's check order is set to 'success', the user's membership will be approved.

Closes Issue: #46.

### How to test the changes in this Pull Request:

1. If a user is approved via the Approvals Add On, their Pay By Check order status will be changed to  'success'
2. If a user's check order is set to 'success', the user's membership will be approved.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Added support for Pay By Check Add On.