### PR TITLE
Bug Fix: Support Register Helper better

### DIFF
--- a/adminpages/userinfo.php
+++ b/adminpages/userinfo.php
@@ -106,9 +106,16 @@ if ( empty( $_REQUEST['user_id'] ) ) {
 					<table class="form-table">
 					<?php
 					//cycle through groups
+
 					foreach ( $fields as $field ) {
 						// show field as long as it's not false
 						if ( false != $field->profile ) {
+
+						// Check to see if level is set for the field.
+						if ( isset( $field->levels ) && ! in_array( $level_details->ID, $field->levels ) ) {
+							break;
+						}
+							
 						?>
 						<tr>
 							<th><label><?php echo esc_attr( $field->label ); ?></label></th>


### PR DESCRIPTION
BUG FIX: Fixed an issue where multiple fields belonging to different levels with the same name would show up twice on the view info page of the approvals. This now supports the 'level' attribute inside Register Helper when displaying fields.