### PR TITLE
Added a filter for the restrict checkout option

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -283,6 +283,22 @@ class PMPro_Approvals {
 		return $requires_approval;
 	}
 
+    /**
+     * Check if level has a restriction level at checkout
+     */
+    public static function restrictCheckout( $level_id = null ) {
+        //no level?
+        if ( empty( $level_id ) ) {
+            return false;
+        }
+        
+        $options = self::getOptions( $level_id );
+
+        $restrict_checkout = apply_filters( 'pmpro_approvals_level_restrict_checkout', $options['restrict_checkout'], $level_id);
+
+        return $restrict_checkout;
+    }
+
 	/**
 	* Load check box to make level require membership.
 	* Fires on pmpro_membership_level_after_other_settings
@@ -529,14 +545,14 @@ class PMPro_Approvals {
 		}
 
 		//does this level require approval of another level?
-		$options = self::getOptions( $pmpro_level->id );
-		if ( $options['restrict_checkout'] ) {
-			$other_level = pmpro_getLevel( $options['restrict_checkout'] );
+		$restrict_checkout = self::restrictCheckout( $pmpro_level->id );
+		if ( $restrict_checkout ) {
+			$other_level = pmpro_getLevel( $restrict_checkout );
 
 			//check that they are approved and not denied for that other level
-			if ( self::isDenied( null, $options['restrict_checkout'] ) ) {
+			if ( self::isDenied( null, $restrict_checkout ) ) {
 				pmpro_setMessage( sprintf( __( 'Since your application to the %s level has been denied, you may not check out for this level.', 'pmpro-approvals' ), $other_level->name ), 'pmpro_error' );
-			} elseif ( self::isPending( null, $options['restrict_checkout'] ) ) {
+			} elseif ( self::isPending( null, $restrict_checkout ) ) {
 				//note we use pmpro_getMembershipLevelForUser instead of pmpro_hasMembershipLevel because the latter is filtered
 				$user_level = pmpro_getMembershipLevelForUser( $current_user->ID );
 				if ( ! empty( $user_level ) && $user_level->id == $other_level->id ) {


### PR DESCRIPTION


### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This request includes a function virtually identical to the "requiresApproval" method that allows filters to be applied to the "requires_approval" option, except that filters are applied to the "restrict_checkout" option. This has specific value for the checkout page that restricts users from checking out if another level requires approval.

This has specific application for the need to automatically approve members that were previously approved but their membership has since lapsed. 

Does not close, but helps address issue: #117 

### How to test the changes in this Pull Request:

1. Create a new filter, `add_filter( 'pmpro_approvals_level_restrict_checkout', 'approve_previous_members', 10, 2 );`
2. Have it return false (for testing).
3. Notice that now on the checkout page, the user will always be approved for their membership application.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
* added a new method "restrictCheckout" that applies filter to the option of the same name
* updated the "pmpro_checkout_preheader" method to utilize the restrictCheckout method