### PR TITLE
add level variable to  denied data filter

### DIFF
--- a/classes/class.approvalemails.php
+++ b/classes/class.approvalemails.php
@@ -87,7 +87,7 @@ class PMPro_Approvals_Email extends PMProEmail {
 		$this->from     = pmpro_getOption( 'from' );
 		$this->fromname = pmpro_getOption( 'from_name' );
 
-		$this->data = apply_filters( 'pmpro_approvals_member_denied_email_data', $this->data, $member );
+		$this->data = apply_filters( 'pmpro_approvals_member_denied_email_data', $this->data, $member, $level );
 
 		return $this->sendEmail();
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add `$level` variable to the `pmpro_approvals_member_denied_email_data` filter as what the approved email data filter has to allow obtaining level-specific data that may be useful when creating custom email template variables depending on data in the level object.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.