### PR TITLE
Fix bug where checking out for same level would approve user.

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -1138,8 +1138,8 @@ class PMPro_Approvals {
 	 */
 	public static function pmpro_before_change_membership_level( $level_id, $user_id, $old_levels, $cancel_level ) {
 
-		// First see if the user is cancelling, try to clean up approval data if they are pending.
-		if ( $level_id == 0 || isset( $old_levels[0]->ID ) ) {
+		// First see if the user is cancelling. If so, try to clean up approval data if they are pending.
+		if ( $level_id == 0 ) {
 			if ( self::isPending( $user_id, $old_levels[0]->ID ) ) {
 				self::clearApprovalData( $user_id, $old_levels[0]->ID, apply_filters( 'pmpro_approvals_delete_log_on_cancel', false ) );
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixed bug where if a user was pending for a level and they checked out for the level again, the "pending" flag would be removed from their membership and they would be considered to be approved.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.