### PR TITLE
Not returning early to make sure pmproap_user_is_approved filter stil…

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -767,9 +767,9 @@ class PMPro_Approvals {
 			$level = pmpro_getMembershipLevelForUser( $user_id );
 
 			if ( empty( $level ) || ( ! empty( $level_id ) && $level->id != $level_id ) ) {
-				return false;
+				$user_approval = array( 'status' => 'pending' );
 			} else {
-				return true;
+				$user_approval = array( 'status' => 'approved' );
 			}
 		}
 
@@ -1187,7 +1187,12 @@ class PMPro_Approvals {
 		//check if level requires approval, if not stop executing this function and don't send email.
 		if ( ! self::requiresApproval( $level_id ) ) {
 			return;
-		}		
+		}
+		
+		//if they are already approved, keep them approved
+		if ( self::isApproved( $user_id, $level_id ) ) {
+			return;
+		}
 
 		//send email to admin that a new member requires approval.
 		$email = new PMPro_Approvals_Email();


### PR DESCRIPTION
…l runs. Also checking approval before sending emails after membership level change.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The earlier return true/false in this method meant that we wouldn't run the filter below which is needed to override the default behavior. For example, gists like this won't work without this fix: https://gist.github.com/ideadude/99714ad43279aac85f086fc0c0b703f4

Instead of returning true or false, this PR sets up an array that looks like user status approved or pending so the filter below functions as expected.

I'm not sure if setting the status here to 'pending' is the best option for what used to be false.

I'm not sure if we want to set some of the other properties of the array, maybe at least to empty fields in case filters look for them.

I also edited the method that is called after membership level change to check if the user is already approved before sending the pending emails. This will prevent those emails from being sent if some other code approved the user already or the pmproap_user_is_approved filter is being used.

### How to test the changes in this Pull Request:

1. You can apply this gist: https://gist.github.com/ideadude/99714ad43279aac85f086fc0c0b703f4
2. Check out for a level that requires approval.
3. Approve the user.
4. Have the user cancel their membership, then checkout again.
5. The second time, the user should not require approval again because this filter ran.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.