### PR TITLE
Level template and new section for level add/edit page for PMPro v2.9+

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -319,7 +319,7 @@ class PMPro_Approvals {
 
 		// Get the template if passed in the URL.
 		if ( isset( $_REQUEST['template'] ) ) {
-			$template = $_REQUEST['template'];
+			$template = sanitize_text_field( $_REQUEST['template'] );
 		} else {
 			$template = false;
 		}
@@ -377,14 +377,14 @@ class PMPro_Approvals {
 				<table class="form-table">
 					<tbody>
 						<tr>
-							<th scope="row" valign="top"><label for="approval_setting"><?php _e( 'Requires Approval?', 'pmpro-approvals' ); ?></label></th>
+							<th scope="row" valign="top"><label for="approval_setting"><?php esc_html_e( 'Requires Approval?', 'pmpro-approvals' ); ?></label></th>
 							<td>
 								<select id="approval_setting" name="approval_setting">
-									<option value="0" <?php selected( $approval_setting, 0 ); ?>><?php _e( 'No.', 'pmpro-approvals' ); ?></option>
-									<option value="1" <?php selected( $approval_setting, 1 ); ?>><?php _e( 'Yes. Admin must approve new members for this level.', 'pmpro-approvals' ); ?></option>
+									<option value="0" <?php selected( $approval_setting, 0 ); ?>><?php esc_html_e( 'No.', 'pmpro-approvals' ); ?></option>
+									<option value="1" <?php selected( $approval_setting, 1 ); ?>><?php esc_html_e( 'Yes. Admin must approve new members for this level.', 'pmpro-approvals' ); ?></option>
 									<?php if ( ! empty( $levels ) ) { ?>
-										<option value="2" <?php selected( $approval_setting, 2 ); ?>><?php _e( 'Yes. User must have an approved membership for a different level.', 'pmpro-approvals' ); ?></option>
-										<option value="3" <?php selected( $approval_setting, 3 ); ?>><?php _e( 'Yes. User must have an approved membership for a different level AND admin must approve new members for this level.', 'pmpro-approvals' ); ?></option>
+										<option value="2" <?php selected( $approval_setting, 2 ); ?>><?php esc_html_e( 'Yes. User must have an approved membership for a different level.', 'pmpro-approvals' ); ?></option>
+										<option value="3" <?php selected( $approval_setting, 3 ); ?>><?php esc_html_e( 'Yes. User must have an approved membership for a different level AND admin must approve new members for this level.', 'pmpro-approvals' ); ?></option>
 									<?php } ?>
 								</select>
 							</td>
@@ -395,7 +395,7 @@ class PMPro_Approvals {
 						if ( $approval_setting < 2 ) {
 				?>
 			 style="display: none;"<?php } ?>>
-							<th scope="row" valign="top"><label for="approval_restrict_level"><?php _e( 'Which Level?', 'pmpro-approvals' ); ?></label></th>
+							<th scope="row" valign="top"><label for="approval_restrict_level"><?php esc_html_e( 'Which Level?', 'pmpro-approvals' ); ?></label></th>
 							<td>
 								<select id="approval_restrict_level" name="approval_restrict_level">					
 								<?php
@@ -1464,7 +1464,7 @@ class PMPro_Approvals {
 		?>
 		<table id="pmpro_approvals_status_table" class="form-table">
 			<tr>
-				<th><?php _e( 'Approval Status', 'pmpro-approvals' ); ?></th>
+				<th><?php esc_html_e( 'Approval Status', 'pmpro-approvals' ); ?></th>
 
 				<td>
 					<span id="pmpro_approvals_status_text">
@@ -1494,7 +1494,7 @@ style="display: none;"<?php } ?>>
 			if ( current_user_can( 'edit_users' ) || current_user_can( 'pmpro_approvals' ) ) {
 			?>
 			<tr>
-				<th><?php _e( 'User Approval Log', 'pmpro-approvals' ); ?></th>
+				<th><?php esc_html_e( 'User Approval Log', 'pmpro-approvals' ); ?></th>
 					<td>
 					<?php
 					echo self::showUserLog( $user->ID );

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -352,7 +352,7 @@ class PMPro_Approvals {
 			<div class="pmpro_section_toggle">
 				<button class="pmpro_section-toggle-button" type="button" aria-expanded="<?php echo $section_visibility === 'hidden' ? 'false' : 'true'; ?>">
 					<span class="dashicons dashicons-arrow-<?php echo $section_visibility === 'hidden' ? 'down' : 'up'; ?>-alt2"></span>
-					<?php esc_html_e( 'Approval Settings', 'paid-memberships-pro' ); ?>
+					<?php esc_html_e( 'Approval Settings', 'pmpro-approvals' ); ?>
 				</button>
 			</div>
 			<div class="pmpro_section_inside" <?php echo $section_visibility === 'hidden' ? 'style="display: none"' : ''; ?>>

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -317,8 +317,21 @@ class PMPro_Approvals {
 	public static function pmpro_membership_level_settings() {
 		$level_id = $_REQUEST['edit'];
 
+		// Get the template if passed in the URL.
+		if ( isset( $_REQUEST['template'] ) ) {
+			$template = $_REQUEST['template'];
+		} else {
+			$template = false;
+		}
+
+		// Get approval settings or set defaults if this is a new approvals level.
 		if ( $level_id > 0 ) {
 			$options = self::getOptions( $level_id );
+		} elseif ( $template === 'approvals' ) {
+			$options = array(
+				'requires_approval' => true,
+				'restrict_checkout' => true,
+			);
 		} else {
 			$options = array(
 				'requires_approval' => false,
@@ -343,10 +356,15 @@ class PMPro_Approvals {
 			unset( $levels[ $level_id ] );   //remove this level
 
 		}
-		?>
-		<?php
+
+		// Hide or show this section based on settings
+		if ( $template === 'approvals' || $approval_setting > 0 ) {
 			$section_visibility = 'shown';
 			$section_activated = 'true';
+		} else {
+			$section_visibility = 'hidden';
+			$section_activated = 'false';
+		}
 		?>
 		<div id="approval-settings" class="pmpro_section" data-visibility="<?php echo esc_attr( $section_visibility ); ?>" data-activated="<?php echo esc_attr( $section_activated ); ?>">
 			<div class="pmpro_section_toggle">

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -91,13 +91,20 @@ class PMPro_Approvals {
 		//add approval status to members list
 		add_action( 'pmpro_members_list_user', array( 'PMPro_Approvals', 'pmpro_members_list_user' ) );
 
+		//filter to add the approval membership level template
+		add_filter( 'pmpro_membershiplevels_template_level', array( 'PMPro_Approvals', 'pmpro_membershiplevels_template_level' ), 10, 2 );
+
 		//filter membership and content access
 		add_filter( 'pmpro_has_membership_level', array( 'PMPro_Approvals', 'pmpro_has_membership_level' ), 10, 3 );
 		add_filter( 'pmpro_has_membership_access_filter', array( 'PMPro_Approvals', 'pmpro_has_membership_access_filter' ), 10, 4 );
 		add_filter( 'pmpro_member_shortcode_access', array( 'PMPro_Approvals', 'pmpro_member_shortcode_access' ), 10, 4 );
 
 		//load checkbox in membership level edit page for users to select.
-		add_action( 'pmpro_membership_level_after_other_settings', array( 'PMPro_Approvals', 'pmpro_membership_level_after_other_settings' ) );
+		if ( defined( 'PMPRO_VERSION' ) && PMPRO_VERSION >= '2.9' ) {
+			add_action( 'pmpro_membership_level_before_billing_information', array( 'PMPro_Approvals', 'pmpro_membership_level_settings' ) );
+		} else {
+			add_action( 'pmpro_membership_level_after_other_settings', array( 'PMPro_Approvals', 'pmpro_membership_level_settings' ) );
+		}
 		add_action( 'pmpro_save_membership_level', array( 'PMPro_Approvals', 'pmpro_save_membership_level' ) );
 
 		//Add code for filtering checkouts, confirmation, and content filters
@@ -306,9 +313,8 @@ class PMPro_Approvals {
 
 	/**
 	* Load check box to make level require membership.
-	* Fires on pmpro_membership_level_after_other_settings
 	*/
-	public static function pmpro_membership_level_after_other_settings() {
+	public static function pmpro_membership_level_settings() {
 		$level_id = $_REQUEST['edit'];
 
 		if ( $level_id > 0 ) {
@@ -338,61 +344,74 @@ class PMPro_Approvals {
 
 		}
 		?>
-		<h3 class="topborder"><?php _e( 'Approval Settings', 'pmpro-approvals' ); ?></h3>
-		<table>
-		<tbody class="form-table">			
-			<tr>
-				<th scope="row" valign="top"><label for="approval_setting"><?php _e( 'Requires Approval?', 'pmpro-approvals' ); ?></label></th>
-				<td>
-					<select id="approval_setting" name="approval_setting">
-						<option value="0" <?php selected( $approval_setting, 0 ); ?>><?php _e( 'No.', 'pmpro-approvals' ); ?></option>
-						<option value="1" <?php selected( $approval_setting, 1 ); ?>><?php _e( 'Yes. Admin must approve new members for this level.', 'pmpro-approvals' ); ?></option>
+		<?php
+			$section_visibility = 'shown';
+			$section_activated = 'true';
+		?>
+		<div id="approval-settings" class="pmpro_section" data-visibility="<?php echo esc_attr( $section_visibility ); ?>" data-activated="<?php echo esc_attr( $section_activated ); ?>">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="<?php echo $section_visibility === 'hidden' ? 'false' : 'true'; ?>">
+					<span class="dashicons dashicons-arrow-<?php echo $section_visibility === 'hidden' ? 'down' : 'up'; ?>-alt2"></span>
+					<?php esc_html_e( 'Approval Settings', 'paid-memberships-pro' ); ?>
+				</button>
+			</div>
+			<div class="pmpro_section_inside" <?php echo $section_visibility === 'hidden' ? 'style="display: none"' : ''; ?>>
+				<table class="form-table">
+					<tbody>
+						<tr>
+							<th scope="row" valign="top"><label for="approval_setting"><?php _e( 'Requires Approval?', 'pmpro-approvals' ); ?></label></th>
+							<td>
+								<select id="approval_setting" name="approval_setting">
+									<option value="0" <?php selected( $approval_setting, 0 ); ?>><?php _e( 'No.', 'pmpro-approvals' ); ?></option>
+									<option value="1" <?php selected( $approval_setting, 1 ); ?>><?php _e( 'Yes. Admin must approve new members for this level.', 'pmpro-approvals' ); ?></option>
+									<?php if ( ! empty( $levels ) ) { ?>
+										<option value="2" <?php selected( $approval_setting, 2 ); ?>><?php _e( 'Yes. User must have an approved membership for a different level.', 'pmpro-approvals' ); ?></option>
+										<option value="3" <?php selected( $approval_setting, 3 ); ?>><?php _e( 'Yes. User must have an approved membership for a different level AND admin must approve new members for this level.', 'pmpro-approvals' ); ?></option>
+									<?php } ?>
+								</select>
+							</td>
+						</tr>
 						<?php if ( ! empty( $levels ) ) { ?>
-							<option value="2" <?php selected( $approval_setting, 2 ); ?>><?php _e( 'Yes. User must have an approved membership for a different level.', 'pmpro-approvals' ); ?></option>
-							<option value="3" <?php selected( $approval_setting, 3 ); ?>><?php _e( 'Yes. User must have an approved membership for a different level AND admin must approve new members for this level.', 'pmpro-approvals' ); ?></option>
+						<tr 
+						<?php
+						if ( $approval_setting < 2 ) {
+				?>
+			 style="display: none;"<?php } ?>>
+							<th scope="row" valign="top"><label for="approval_restrict_level"><?php _e( 'Which Level?', 'pmpro-approvals' ); ?></label></th>
+							<td>
+								<select id="approval_restrict_level" name="approval_restrict_level">					
+								<?php
+								foreach ( $levels as $level ) {
+									?>
+									<option value="<?php echo $level->id; ?>" <?php selected( $options['restrict_checkout'], $level->id ); ?>><?php echo $level->name; ?></option>
+										<?php
+								}
+								?>
+							</td>
+						</tr>
 						<?php } ?>
-					</select>								
-				</td>
-			</tr>
-			<?php if ( ! empty( $levels ) ) { ?>
-			<tr 
-			<?php
-			if ( $approval_setting < 2 ) {
-	?>
- style="display: none;"<?php } ?>>
-				<th scope="row" valign="top"><label for="approval_restrict_level"><?php _e( 'Which Level?', 'pmpro-approvals' ); ?></label></th>
-				<td>
-					<select id="approval_restrict_level" name="approval_restrict_level">					
-					<?php
-					foreach ( $levels as $level ) {
-						?>
-						<option value="<?php echo $level->id; ?>" <?php selected( $options['restrict_checkout'], $level->id ); ?>><?php echo $level->name; ?></option>
-							<?php
-					}
-					?>
-				</td>
-			</tr>
-			<?php } ?>
-		</tbody>
-		</table>
-		<?php if ( ! empty( $levels ) ) { ?>
-		<script>
-			jQuery(document).ready(function() {
-				function pmproap_toggleWhichLevel() {
-					if(jQuery('#approval_setting').val() > 1)
-						jQuery('#approval_restrict_level').closest('tr').show();
-					else
-						jQuery('#approval_restrict_level').closest('tr').hide();
-				}
-				
-				//bind to approval setting change
-				jQuery('#approval_setting').change(function() { pmproap_toggleWhichLevel(); });
-				
-				//run on load
-				pmproap_toggleWhichLevel();
-			});
-		</script>
-		<?php } ?>
+					</tbody>
+				</table>
+				<?php if ( ! empty( $levels ) ) { ?>
+					<script>
+						jQuery(document).ready(function() {
+							function pmproap_toggleWhichLevel() {
+								if(jQuery('#approval_setting').val() > 1)
+									jQuery('#approval_restrict_level').closest('tr').show();
+								else
+									jQuery('#approval_restrict_level').closest('tr').hide();
+							}
+							
+							//bind to approval setting change
+							jQuery('#approval_setting').change(function() { pmproap_toggleWhichLevel(); });
+							
+							//run on load
+							pmproap_toggleWhichLevel();
+						});
+					</script>
+				<?php } ?>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end pmpro_section -->
 		<?php
 	}
 
@@ -1280,6 +1299,24 @@ class PMPro_Approvals {
 
 	return $user;
 }
+
+	/**
+	 * Add the approval membership level template
+	 */
+	public static function pmpro_membershiplevels_template_level( $level, $template ) {
+		if ( $template === 'approvals' ) {
+			$level->billing_amount = NULL;
+			$level->trial_amount = NULL;
+			$level->initial_payment = NULL;
+			$level->billing_limit = NULL;
+			$level->trial_limit = NULL;
+			$level->expiration_number = NULL;
+			$level->expiration_period = NULL;
+			$level->cycle_number = 1;
+			$level->cycle_period = 'Month';
+		}
+		return $level;
+	}
 
 	/**
 	 * Custom confirmation message for levels that requires approval.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The redesign of the Membership Levels page + templates are slated for PMPro v2.9. We are including Approvals in the template list. This PR updates the Approval Settings section to match the v2.9+ format for the levels admin page.

<img width="1024" alt="Screen Shot 2022-05-26 at 6 39 01 AM" src="https://user-images.githubusercontent.com/5312875/170472086-b464a347-3264-4842-b266-f991bae52335.png">

v2.9 adds new hooks so that Add Ons like this can place their settings in more places on the edit page. I have conditionally used the new hook to show this box right below the general settings of that new UI.

<img width="1246" alt="Screen Shot 2022-05-26 at 6 38 26 AM" src="https://user-images.githubusercontent.com/5312875/170472001-7a4c242f-47f5-409c-b320-14900086107c.png">

For sites that are not on 2.9, the settings section will be shown as it is today at the bottom of the page.

Note that the appearance is a bit less than perfect since the new format relies on CSS in core PMPro v2.9+. I think rather than replicate this formatting or code to variations of the section we add based on PMPro version we just live with this less than desirable look and believe that people will upgrade core.

<img width="1182" alt="Screen Shot 2022-05-26 at 6 32 18 AM" src="https://user-images.githubusercontent.com/5312875/170472016-2c7040f8-b22e-4a0a-9127-7c399db23ff7.png">

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Check out the pending PR for the 'edit-levels-templates-cycle' from my GitHub user.
2. Go to Settings > Levels. Click Add New.
3. You'll see the "Approvals" template. Click that.
4. On the Edit page, see the "Approval Settings" section right below the "General Information" section.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* ENHANCEMENT: Added Approval level template and support for PMPro v2.9+ settings UI.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.