### PR TITLE
Added MMPU compatibility

### DIFF
--- a/adminpages/approvals.php
+++ b/adminpages/approvals.php
@@ -34,17 +34,23 @@ if ( empty( $status ) || ! in_array( $status, $statuses ) ) {
 	//Approve, deny or reset member back to pending
 if ( ! empty( $_REQUEST['approve'] ) ) {
 	check_admin_referer( 'pmpro_approvals', 'pmpro_approvals_nonce' );
-	if ( ! PMPro_Approvals::isApproved( intval( $_REQUEST['approve'] ) ) ) {
+	if ( ! PMPro_Approvals::isApproved( intval( $_REQUEST['approve'] ), $l ) ) {
 		PMPro_Approvals::approveMember( intval( $_REQUEST['approve'] ), $l );
+		$l = false;
+		$status = 'pending';
 	}
 } elseif ( ! empty( $_REQUEST['deny'] ) ) {
 	check_admin_referer( 'pmpro_approvals', 'pmpro_approvals_nonce' );
-	if ( ! PMPro_Approvals::isDenied( intval( $_REQUEST['deny'] ) ) ) {
+	if ( ! PMPro_Approvals::isDenied( intval( $_REQUEST['deny'] ), $l ) ) {
 		PMPro_Approvals::denyMember( intval( $_REQUEST['deny'] ), $l );
+		$l = false;
+		$status = 'pending';
 	}
 } elseif ( ! empty( $_REQUEST['unapprove'] ) ) {
 	check_admin_referer( 'pmpro_approvals', 'pmpro_approvals_nonce' );
 	PMPro_Approvals::resetMember( intval( $_REQUEST['unapprove'] ), $l );
+	$l = false;
+	$status = 'pending';
 }
 
 	require_once PMPRO_DIR . '/adminpages/admin_header.php';
@@ -137,16 +143,17 @@ selected="selected"<?php } ?>><?php _e( 'All Levels', 'pmpro-approvals' ); ?></o
 		$limit = 15;
 	}
 
-		$theusers  = PMPro_Approvals::getApprovals( $l, $s, $status, $sortby, $sortorder, $pn, $limit );
+		$approval_users  = PMPro_Approvals::getApprovals( $l, $s, $status, $sortby, $sortorder, $pn, $limit );
 		$totalrows = $wpdb->get_var( 'SELECT FOUND_ROWS() as found_rows' );
 
-	if ( $theusers ) {
+	if ( $approval_users ) {
 		?>
 		<p class="clear">
-		<?php
-		if ( $l == 1 ) {
-?>
-<?php echo $totalrows; ?> <?php _e( 'applications awaiting review', 'pmpro-approvals' ); ?>.<?php } ?>
+			<?php
+			if ( $status === 'pending' ) {
+			?>
+				<?php echo $totalrows; ?> <?php _e( 'applications awaiting review', 'pmpro-approvals' ); ?>.
+			<?php } ?>
 		</p>
 		<?php
 	}
@@ -158,7 +165,7 @@ selected="selected"<?php } ?>><?php _e( 'All Levels', 'pmpro-approvals' ); ?></o
 				<th><?php _e( 'Username', 'pmpro-approvals' ); ?></th>
 				<th><?php _e( 'Name', 'pmpro-approvals' ); ?></th>				
 				<th><?php _e( 'Email', 'pmpro-approvals' ); ?></th>
-				<?php do_action( 'pmpro_approvals_list_extra_cols_header', $theusers ); ?>
+				<?php do_action( 'pmpro_approvals_list_extra_cols_header', $approval_users ); ?>
 				<th><?php _e( 'Membership', 'pmpro-approvals' ); ?></th>					
 				<th><?php _e( 'Approval Status', 'pmpro-approvals' ); ?></th>
 				<th><a href="<?php echo admin_url( 'admin.php?page=pmpro-approvals&s=' . esc_attr( $s ) . '&limit=' . $limit . '&pn=' . $pn . '&sortby=user_registered' ); ?>
@@ -171,28 +178,27 @@ selected="selected"<?php } ?>><?php _e( 'All Levels', 'pmpro-approvals' ); ?></o
 		<tbody id="users" class="list:user user-list">	
 			<?php
 				$count = 0;
-			foreach ( $theusers as $auser ) {
+			foreach ( $approval_users as $approval_user ) {
 				//get meta
-				$theuser                   = get_userdata( $auser->ID );
-				$theuser->membership_level = pmpro_getMembershipLevelForUser( $theuser->ID );
+				$user_data = get_userdata( $approval_user->ID );
 				?>
 					<tr 
 					<?php
 					if ( $count++ % 2 == 0 ) {
 ?>
 class="alternate"<?php } ?>>
-						<td><?php echo $theuser->ID; ?></td>
+						<td><?php echo $user_data->ID; ?></td>
 						<td class="username column-username">
-							<?php echo get_avatar( $theuser->ID, 32 ); ?>								
+							<?php echo get_avatar( $user_data->ID, 32 ); ?>								
 							<?php if ( current_user_can( 'edit_users' ) ) { ?>
-									<strong><a href="user-edit.php?user_id=<?php echo $theuser->ID; ?>"><?php echo $theuser->user_login; ?></a></strong>
+									<strong><a href="user-edit.php?user_id=<?php echo $user_data->ID; ?>"><?php echo $user_data->user_login; ?></a></strong>
 								<?php } else { ?>
-									<strong><a href="admin.php?page=pmpro-approvals&user_id=<?php echo $theuser->ID; ?>"><?php echo $theuser->user_login; ?></a></strong>
+									<strong><a href="admin.php?page=pmpro-approvals&user_id=<?php echo $user_data->ID; ?>"><?php echo $user_data->user_login; ?></a></strong>
 								<?php } ?>
 							<br />
 							<?php
 								// Set up the hover actions for this user
-								$actions      = apply_filters( 'pmpro_approvals_user_row_actions', array(), $theuser );
+								$actions      = apply_filters( 'pmpro_approvals_user_row_actions', array(), $user_data, $approval_user );
 								$action_count = count( $actions );
 								$i            = 0;
 							if ( $action_count ) {
@@ -207,46 +213,46 @@ class="alternate"<?php } ?>>
 							}
 								?>
 							</td>
-							<td><?php echo trim( $theuser->first_name . ' ' . $theuser->last_name ); ?></td>							
-							<td><a href="mailto:<?php echo $theuser->user_email; ?>"><?php echo $theuser->user_email; ?></a></td>
-							<?php do_action( 'pmpro_approvals_list_extra_cols_body', $theuser ); ?>						
+							<td><?php echo trim( $user_data->first_name . ' ' . $user_data->last_name ); ?></td>							
+							<td><a href="mailto:<?php echo $user_data->user_email; ?>"><?php echo $user_data->user_email; ?></a></td>
+							<?php do_action( 'pmpro_approvals_list_extra_cols_body', $user_data ); ?>						
 							<td>
 								<?php
-								echo $auser->membership;
+								echo $approval_user->membership;
 								?>
 							</td>						
 							<td>										
 								<?php
 								$pmpro_approvals_nonce = wp_create_nonce( 'pmpro_approvals' );
 
-								if ( PMPro_Approvals::isApproved( $theuser->ID ) || PMPro_Approvals::isDenied( $theuser->ID ) ) {
+								if ( PMPro_Approvals::isApproved( $user_data->ID, $approval_user->membership_id) || PMPro_Approvals::isDenied( $user_data->ID, $approval_user->membership_id ) ) {
 
-									if ( ! PMPro_Approvals::getEmailConfirmation( $theuser->ID ) ) {
+									if ( ! PMPro_Approvals::getEmailConfirmation( $user_data->ID ) ) {
 										_e( 'Email Confirmation Required.', 'pmpro-approvals' );
 									} else {
 
-										echo PMPro_Approvals::getUserApprovalStatus( $theuser->ID, $theuser->membership_level->id, false );
+										echo PMPro_Approvals::getUserApprovalStatus( $user_data->ID, $approval_user->membership_id, false );
 
 										//link to unapprove
 										?>
-										[<a href="javascript:askfirst('Are you sure you want to reset approval for <?php echo $theuser->user_login; ?>?', '?page=pmpro-approvals&s=<?php echo esc_attr( $s ); ?>&l=<?php echo $l; ?>&limit=<?php echo intval( $limit ); ?>&status=<?php echo $status; ?>&sortby=<?php echo $sortby; ?>&sortorder=<?php echo $sortorder; ?>&pn=<?php echo intval( $pn ); ?>&unapprove=<?php echo $theuser->ID; ?>&pmpro_approvals_nonce=<?php echo urlencode( $pmpro_approvals_nonce ); ?>');">X</a>]
+										[<a href="javascript:askfirst('Are you sure you want to reset approval for <?php echo $user_data->user_login; ?>?', '?page=pmpro-approvals&s=<?php echo esc_attr( $s ); ?>&l=<?php echo $approval_user->membership_id; ?>&limit=<?php echo intval( $limit ); ?>&status=<?php echo $status; ?>&sortby=<?php echo $sortby; ?>&sortorder=<?php echo $sortorder; ?>&pn=<?php echo intval( $pn ); ?>&unapprove=<?php echo $user_data->ID; ?>&pmpro_approvals_nonce=<?php echo urlencode( $pmpro_approvals_nonce ); ?>');">X</a>]
 										<?php
 									}
 								} else {
 									?>
 																			
-									<a href="?page=pmpro-approvals&s=<?php echo esc_attr( $s ); ?>&l=<?php echo $l; ?>&limit=<?php echo intval( $limit ); ?>&status=<?php echo $status; ?>&sortby=<?php echo $sortby; ?>&sortorder=<?php echo $sortorder; ?>&pn=<?php echo intval( $pn ); ?>&approve=<?php echo $theuser->ID; ?>&pmpro_approvals_nonce=<?php echo urlencode( $pmpro_approvals_nonce ); ?>"><?php _e('Approve', 'pmpro-approvals') ?></a> |
-									<a href="?page=pmpro-approvals&s=<?php echo esc_attr( $s ); ?>&l=<?php echo $l; ?>&limit=<?php echo intval( $limit ); ?>&status=<?php echo $status; ?>&sortby=<?php echo $sortby; ?>&sortorder=<?php echo $sortorder; ?>&pn=<?php echo intval( $pn ); ?>&deny=<?php echo $theuser->ID; ?>&pmpro_approvals_nonce=<?php echo urlencode( $pmpro_approvals_nonce ); ?>"><?php _e('Deny', 'pmpro-approvals') ?></a>
+									<a href="?page=pmpro-approvals&s=<?php echo esc_attr( $s ); ?>&l=<?php echo $approval_user->membership_id; ?>&limit=<?php echo intval( $limit ); ?>&status=<?php echo $status; ?>&sortby=<?php echo $sortby; ?>&sortorder=<?php echo $sortorder; ?>&pn=<?php echo intval( $pn ); ?>&approve=<?php echo $user_data->ID; ?>&pmpro_approvals_nonce=<?php echo urlencode( $pmpro_approvals_nonce ); ?>"><?php _e('Approve', 'pmpro-approvals') ?></a> |
+									<a href="?page=pmpro-approvals&s=<?php echo esc_attr( $s ); ?>&l=<?php echo $approval_user->membership_id; ?>&limit=<?php echo intval( $limit ); ?>&status=<?php echo $status; ?>&sortby=<?php echo $sortby; ?>&sortorder=<?php echo $sortorder; ?>&pn=<?php echo intval( $pn ); ?>&deny=<?php echo $user_data->ID; ?>&pmpro_approvals_nonce=<?php echo urlencode( $pmpro_approvals_nonce ); ?>"><?php _e('Deny', 'pmpro-approvals') ?></a>
 									<?php
 								}
 								?>
 							</td>
-							<td><?php echo date_i18n( get_option( 'date_format' ), strtotime( $theuser->user_registered ) ); ?></td>							
+							<td><?php echo date_i18n( get_option( 'date_format' ), strtotime( $user_data->user_registered ) ); ?></td>							
 						</tr>
 					<?php
 			}
 
-			if ( ! $theusers ) {
+			if ( ! $approval_users ) {
 				?>
 				<tr>
 				<td colspan="9"><p><?php _e( 'No pending members found.', 'pmpro-approvals' ); ?></p></td>

--- a/adminpages/userinfo.php
+++ b/adminpages/userinfo.php
@@ -9,7 +9,13 @@ if ( ! function_exists( 'current_user_can' ) || ! current_user_can( 'pmpro_appro
 if ( isset( $_REQUEST['l'] ) ) {
 	$l = intval( $_REQUEST['l'] );
 } else {
-	$l = false;
+	// Default to a random level that the user has. Hopefully we never actually do this.
+	$levels = pmpro_getMembershipLevelsForUser( $current_user->ID );
+	if ( ! empty( $levels ) ) {
+		$l = $levels[0]->id;
+	} else {
+		$l = 0;
+	}
 }
 
 if ( ! empty( $_REQUEST['approve'] ) ) {
@@ -59,7 +65,7 @@ if ( empty( $_REQUEST['user_id'] ) ) {
 			<td>
 			<?php
 			//Changed this to show Membership Level Name now, so approvers don't need to go back and forth to see what level the user is applying for.
-			 $level_details = pmpro_getMembershipLevelForUser( $user->ID );
+			 $level_details = pmpro_getSpecificMembershipLevelForUser( $user->ID, $l );
 
 			 echo esc_html( $level_details->name );
         
@@ -71,20 +77,20 @@ if ( empty( $_REQUEST['user_id'] ) ) {
 			<td>
 			<?php
 			//show status here
-			if ( PMPro_Approvals::isApproved( $user->ID ) || PMPro_Approvals::isDenied( $user->ID ) ) {
+			if ( PMPro_Approvals::isApproved( $user->ID, $l ) || PMPro_Approvals::isDenied( $user->ID, $l ) ) {
 				if ( ! PMPro_Approvals::getEmailConfirmation( $user->ID ) ) {
 					_e( 'Email Confirmation Required.', 'pmpro-approvals' );
 				} else {
-					echo PMPro_Approvals::getUserApprovalStatus( $user->ID, null, false );
+					echo PMPro_Approvals::getUserApprovalStatus( $user->ID, $l, false );
 				?>
-				[<a href="javascript:askfirst('Are you sure you want to reset approval for <?php echo esc_attr( $user->user_login ); ?>?', '?page=pmpro-approvals&user_id=<?php echo $user->ID; ?>&unapprove=<?php echo $user->ID; ?>');">X</a>]
+				[<a href="javascript:askfirst('Are you sure you want to reset approval for <?php echo esc_attr( $user->user_login ); ?>?', '?page=pmpro-approvals&user_id=<?php echo $user->ID; ?>&unapprove=<?php echo $user->ID; ?>&l=<?php echo $l ?>');">X</a>]
 				<?php
 				}   // end of email confirmation check.
 			} else {
 			?>
 													
-			<a href="?page=pmpro-approvals&user_id=<?php echo $user->ID; ?>&approve=<?php echo $user->ID; ?>">Approve</a> |
-			<a href="?page=pmpro-approvals&user_id=<?php echo $user->ID; ?>&deny=<?php echo $user->ID; ?>">Deny</a>
+			<a href="?page=pmpro-approvals&user_id=<?php echo $user->ID; ?>&approve=<?php echo $user->ID; ?>&l=<?php echo $l ?>"><?php esc_html_e( 'Approve', 'pmpro-approvals' ); ?></a> |
+			<a href="?page=pmpro-approvals&user_id=<?php echo $user->ID; ?>&deny=<?php echo $user->ID; ?>&l=<?php echo $l ?>"><?php esc_html_e( 'Deny', 'pmpro-approvals' ); ?></a>
 			<?php
 			}
 			?>

--- a/classes/class.approvalemails.php
+++ b/classes/class.approvalemails.php
@@ -20,8 +20,9 @@ class PMPro_Approvals_Email extends PMProEmail {
 	 * Send user's an email that their account has been approved.
 	 *
 	 * @param $member. The member's ID or object.
+	 * @param int $level_id
 	 */
-	public function sendMemberApproved( $member ) {
+	public function sendMemberApproved( $member, $level_id = null ) {
 
 		if ( empty( $member ) ) {
 			return;
@@ -29,7 +30,12 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$member = get_user_by( 'ID', $member );
 		}
 
-		$level = pmpro_getMembershipLevelForUser( $member->ID );
+		if ( empty( $level_id ) ) {
+			$level = pmpro_getMembershipLevelForUser( $member->ID );
+		} else {
+			$level = pmpro_getSpecificMembershipLevelForUser( $member->ID, $level_id );
+		}
+		
 
 		$this->email    = $member->user_email;
 		$this->subject  = sprintf( __( 'Your membership at %s has been approved.', 'pmpro-approvals' ), get_bloginfo( 'name' ) );
@@ -58,8 +64,9 @@ class PMPro_Approvals_Email extends PMProEmail {
 	 * Send user's an email that their account has been denied.
 	 *
 	 * @param $member. The member's ID or object.
+	 * @param int $level_id
 	 */
-	public function sendMemberDenied( $member ) {
+	public function sendMemberDenied( $member, $level_id = null ) {
 
 		if ( empty( $member ) ) {
 			return;
@@ -67,7 +74,11 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$member = get_user_by( 'ID', $member );
 		}
 
-		$level = pmpro_getMembershipLevelForUser( $member->ID );
+		if ( empty( $level_id ) ) {
+			$level = pmpro_getMembershipLevelForUser( $member->ID );
+		} else {
+			$level = pmpro_getSpecificMembershipLevelForUser( $member->ID, $level_id );
+		}
 
 		$this->email    = $member->user_email;
 		$this->subject  = sprintf( __( 'Your membership at %s has been denied.', 'pmpro-approvals' ), get_bloginfo( 'name' ) );
@@ -98,8 +109,9 @@ class PMPro_Approvals_Email extends PMProEmail {
 	 *
 	 * @param $member The member object/ID/email.
 	 * @param $admin The admin object/ID. Default $current_user object.
+	 * @param int $level_id
 	 */
-	public function sendAdminPending( $member = null, $admin = null ) {
+	public function sendAdminPending( $member = null, $admin = null, $level_id = null ) {
 
 		if ( empty( $admin ) ) {
 			$admin = get_user_by( 'email', get_option( 'admin_email' ) );
@@ -130,13 +142,17 @@ class PMPro_Approvals_Email extends PMProEmail {
 				$member = get_user_by( 'email', $member );
 			}
 
-			$level = pmpro_getMembershipLevelForUser( $member->ID );
+			if ( empty( $level_id ) ) {
+				$level = pmpro_getMembershipLevelForUser( $member->ID );
+			} else {
+				$level = pmpro_getSpecificMembershipLevelForUser( $member->ID, $level_id );
+			}
 
 			$this->data['member_name']  = $member->display_name;
 			$this->data['member_email'] = $member->user_email;
 			$this->data['membership_id']         = $level->id;
 			$this->data['membership_level_name'] = $level->name;
-			$this->data['view_profile'] = admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $member->ID );
+			$this->data['view_profile'] = admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $member->ID . '&l=' . $level->id );
 			$this->data['approve_link'] = $this->data['view_profile'] . '&approve=' . $member->ID;
 			$this->data['deny_link']    = $this->data['view_profile'] . '&deny=' . $member->ID;
 		}
@@ -151,8 +167,9 @@ class PMPro_Approvals_Email extends PMProEmail {
 	 *
 	 * @param $member The member object/ID/email.
 	 * @param $admin The admin object/ID. Default $current_user object.
+	 * @param int $level_id
 	 */
-	public function sendAdminApproval( $member = null, $admin = null ) {
+	public function sendAdminApproval( $member = null, $admin = null, $level_id = null ) {
 
 		if ( empty( $admin ) ) {
 			$admin = get_user_by( 'email', get_option( 'admin_email' ) );
@@ -184,13 +201,17 @@ class PMPro_Approvals_Email extends PMProEmail {
 				$member = get_user_by( 'email', $member );
 			}
 
-			$level = pmpro_getMembershipLevelForUser( $member->ID );
+			if ( empty( $level_id ) ) {
+				$level = pmpro_getMembershipLevelForUser( $member->ID );
+			} else {
+				$level = pmpro_getSpecificMembershipLevelForUser( $member->ID, $level_id );
+			}
 
 			$this->data['membership_id']         = $level->id;
 			$this->data['membership_level_name'] = $level->name;
 			$this->data['member_email']          = $member->user_email;
 			$this->data['member_name']           = $member->display_name;
-			$this->data['view_profile']          = admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $member->ID );
+			$this->data['view_profile']          = admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $member->ID . '&l=' . $level->id );
 		}
 
 		$this->data = apply_filters( 'pmpro_approvals_admin_approved_email_data', $this->data, $member, $admin );
@@ -203,8 +224,9 @@ class PMPro_Approvals_Email extends PMProEmail {
 	 *
 	 * @param $member The member object/ID/email.
 	 * @param $admin The admin object/ID. Default $current_user object.
+	 * @param int $level_id
 	 */
-	public function sendAdminDenied( $member = null, $admin = null ) {
+	public function sendAdminDenied( $member = null, $admin = null, $level_id = null ) {
 
 		if ( empty( $admin ) ) {
 			$admin = get_user_by( 'email', get_option( 'admin_email' ) );
@@ -236,13 +258,17 @@ class PMPro_Approvals_Email extends PMProEmail {
 				$member = get_user_by( 'email', $member );
 			}
 
-			$level = pmpro_getMembershipLevelForUser( $member->ID );
+			if ( empty( $level_id ) ) {
+				$level = pmpro_getMembershipLevelForUser( $member->ID );
+			} else {
+				$level = pmpro_getSpecificMembershipLevelForUser( $member->ID, $level_id );
+			}
 
 			$this->data['membership_id']         = $level->id;
 			$this->data['membership_level_name'] = $level->name;
 			$this->data['member_email']          = $member->user_email;
 			$this->data['member_name']           = $member->display_name;
-			$this->data['view_profile']          = admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $member->ID );
+			$this->data['view_profile']          = admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $member->ID . '&l=' . $level->id );
 		}
 
 		$this->data = apply_filters( 'pmpro_approvals_admin_denied_email_data', $this->data, $member, $admin );

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -1177,9 +1177,9 @@ class PMPro_Approvals {
 	public static function pmpro_before_change_membership_level( $level_id, $user_id, $old_levels, $cancel_level ) {
 
 		// First see if the user is cancelling. If so, try to clean up approval data if they are pending.
-		if ( $level_id == 0 ) {
-			if ( self::isPending( $user_id, $old_levels[0]->ID ) ) {
-				self::clearApprovalData( $user_id, $old_levels[0]->ID, apply_filters( 'pmpro_approvals_delete_log_on_cancel', false ) );
+		if ( ! empty( $cancel_level ) ) {
+			if ( self::isPending( $user_id, $cancel_level ) ) {
+				self::clearApprovalData( $user_id, $cancel_level, apply_filters( 'pmpro_approvals_delete_log_on_cancel', false ) );
 			}
 		}
 

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -1463,7 +1463,7 @@ class PMPro_Approvals {
 				<td>
 					<?php
 					// Link to the approvals admin page for this user.
-					$approvals_admin_url = admin_url( 'admin.php?page=pmpro-approvals&s=' . esc_url( $user->nickname ) . '&status=all' );
+					$approvals_admin_url = admin_url( 'admin.php?page=pmpro-approvals&s=' . $user->display_name . '&status=all' );
 					?>
 					<p>
 						<a href="<?php echo esc_url( $approvals_admin_url ); ?>"><?php esc_html_e( 'Manage Approval Statuses', 'pmpro-approvals' ); ?></a>

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -72,7 +72,7 @@ class PMPro_Approvals {
 		add_action( 'admin_init', array( 'PMPro_Approvals', 'admin_init' ) );
 
 		//add user actions to the approvals page
-		add_filter( 'pmpro_approvals_user_row_actions', array( 'PMPro_Approvals', 'pmpro_approvals_user_row_actions' ), 10, 2 );
+		add_filter( 'pmpro_approvals_user_row_actions', array( 'PMPro_Approvals', 'pmpro_approvals_user_row_actions' ), 10, 3 );
 
 		//add approval section to edit user page
 		$membership_level_capability = apply_filters( 'pmpro_edit_member_capability', 'manage_options' );
@@ -116,7 +116,6 @@ class PMPro_Approvals {
 
 		//Integrate with Member Directory.
 		add_filter( 'pmpro_member_directory_sql_parts', array( 'PMPro_Approvals', 'pmpro_member_directory_sql_parts'), 10, 9 );
-		add_filter( 'gettext', array( 'PMPro_Approvals', 'change_your_level_text' ), 10, 3 );
 
 		//Integrate with Pay By Check Add On
 		add_action( 'pmpro_approvals_after_approve_member', array( 'PMPro_Approvals', 'pmpro_pay_by_check_approve' ), 10, 2 );
@@ -664,6 +663,7 @@ class PMPro_Approvals {
 		if ( ! empty( $user_id ) ) {
 			//default to the user's current level
 			if ( empty( $level_id ) ) {
+				_doing_it_wrong( __FUNCTION__, __( 'You should pass a level ID to getUserApproval.', 'pmpro-approvals' ), 'TBD' );
 				$level = pmpro_getMembershipLevelForUser( $user_id );
 				if ( ! empty( $level ) ) {
 					$level_id = $level->id;
@@ -701,6 +701,7 @@ class PMPro_Approvals {
 
 		//get the PMPro level for the user
 		if ( empty( $level_id ) ) {
+			_doing_it_wrong( __FUNCTION__, __( 'You should pass a level ID to getUserApprovalStatus.', 'pmpro-approvals' ), 'TBD' );
 			$level    = pmpro_getMembershipLevelForUser( $user_id );
 			
 			if ( ! empty( $level ) ) {
@@ -799,14 +800,12 @@ class PMPro_Approvals {
 		//get approval for this user/level
 		$user_approval = self::getUserApproval( $user_id, $level_id );
 
-		//if no array, check if they already have the level
 		if ( empty( $user_approval ) || ! is_array( $user_approval ) ) {
-			$level = pmpro_getMembershipLevelForUser( $user_id );
-
-			if ( empty( $level ) || ( ! empty( $level_id ) && $level->id != $level_id ) ) {
-				$user_approval = array( 'status' => 'pending' );
-			} else {
+			// Check if the user had this level before it was set to require approval.
+			if ( ! empty( $level_id ) && self::hasMembershipLevelSansApproval( $level_id, $user_id ) ) {
 				$user_approval = array( 'status' => 'approved' );
+			} else {
+				$user_approval = array( 'status' => 'pending' );
 			}
 		}
 
@@ -863,9 +862,8 @@ class PMPro_Approvals {
 
 		//if no array, check if they already had the level
 		if ( empty( $user_approval ) || ! is_array( $user_approval ) ) {
-			$level = pmpro_getMembershipLevelForUser( $user_id );
-
-			if ( empty( $level ) || ( ! empty( $level_id ) && $level->id != $level_id ) ) {
+			// Check if the user had this level before it was set to require approval.
+			if ( ! empty( $level_id ) && self::hasMembershipLevelSansApproval( $level_id, $user_id ) ) {
 				return true;
 			} else {
 				return false;
@@ -1022,6 +1020,7 @@ class PMPro_Approvals {
 
 		// get user's current level if none given.
 		if ( empty( $level_id ) ) {
+			_doing_it_wrong( __FUNCTION__, __( 'No level ID given. Please pass a level ID to approveMember().', 'pmpro-approvals' ), 'TBD' );
 			$user_level = pmpro_getMembershipLevelForUser( $user_id );
 			$level_id   = $user_level->id;
 		}
@@ -1062,8 +1061,8 @@ class PMPro_Approvals {
 		if ( $send_emails ) {
 			// send email to user and admin.
 			$approval_email = new PMPro_Approvals_Email();
-			$approval_email->sendMemberApproved( $user_id );
-			$approval_email->sendAdminApproval( $user_id );
+			$approval_email->sendMemberApproved( $user_id, $level_id );
+			$approval_email->sendAdminApproval( $user_id, null, $level_id );
 		}
 		
 		self::updateUserLog( $user_id, $level_id );
@@ -1089,6 +1088,7 @@ class PMPro_Approvals {
 
 		//get user's current level if none given
 		if ( empty( $level_id ) ) {
+			_doing_it_wrong( __FUNCTION__, __( 'No level ID given. Please pass a level ID to denyMember().', 'pmpro-approvals' ), 'TBD' );
 			$user_level = pmpro_getMembershipLevelForUser( $user_id );
 			$level_id   = $user_level->id;
 		}
@@ -1114,8 +1114,8 @@ class PMPro_Approvals {
 
 		// Send email to member and admin.
 		$denied_email = new PMPro_Approvals_Email();
-		$denied_email->sendMemberDenied( $user_id );
-		$denied_email->sendAdminDenied( $user_id );
+		$denied_email->sendMemberDenied( $user_id, $level_id );
+		$denied_email->sendAdminDenied( $user_id, null, $level_id );
 
 		self::updateUserLog( $user_id, $level_id );
 
@@ -1141,6 +1141,7 @@ class PMPro_Approvals {
 
 		//get user's current level if none given
 		if ( empty( $level_id ) ) {
+			_doing_it_wrong( __FUNCTION__, __( 'No level ID given. Please pass a level ID to resetMember().', 'pmpro-approvals' ), 'TBD' );
 			$user_level = pmpro_getMembershipLevelForUser( $user_id );
 			$level_id   = $user_level->id;
 		}
@@ -1233,7 +1234,7 @@ class PMPro_Approvals {
 
 		//send email to admin that a new member requires approval.
 		$email = new PMPro_Approvals_Email();
-		$email->sendAdminPending( $user_id );
+		$email->sendAdminPending( $user_id, null, $level_id );
 	}
 
 	/**
@@ -1247,13 +1248,18 @@ class PMPro_Approvals {
 		if ( ! pmpro_hasMembershipLevel() ) {
 			return $text;
 		} else {
-			//get current user's level ID
-			$users_level = pmpro_getMembershipLevelForUser( $current_user->ID );
-			$level_id    = $users_level->ID;
-			if ( self::requiresApproval( $level_id ) && self::isPending() ) {
-				$text = __( 'Your membership requires approval before you are able to view this content.', 'pmpro-approvals' );
-			} elseif ( self::requiresApproval( $level_id ) && self::isDenied() ) {
-				$text = __( 'Your membership application has been denied. Contact the site owners if you believe this is an error.', 'pmpro-approvals' );
+			// Loop through all user levels and check if any are pending approval or denied.
+			$user_levels = pmpro_getMembershipLevelsForUser( $current_user->ID );
+			foreach ( $user_levels as $user_level ) {
+				if ( ! self::requiresApproval( $user_level->id ) ) {
+					continue;
+				}
+
+				if ( self::isPending( $current_user->ID, $user_level->id ) ) {
+					return esc_html__( 'Your membership requires approval before you are able to view this content.', 'pmpro-approvals' );
+				} elseif ( self::isDenied( $current_user->ID, $user_level->id ) ) {
+					return esc_html__( 'Your membership application has been denied. Contact the site owners if you believe this is an error.', 'pmpro-approvals' );
+				}
 			}
 		}
 
@@ -1263,7 +1269,12 @@ class PMPro_Approvals {
 	/**
 	 * Set user action links for approvals page
 	 */
-	public static function pmpro_approvals_user_row_actions( $actions, $user ) {
+	public static function pmpro_approvals_user_row_actions( $actions, $user, $approval_user = null ) {
+		if ( empty( $approval_user ) ) {
+			// Doing it wrong. Approval user should now be passed.
+			_doing_it_wrong( __FUNCTION__, 'The $approval_user parameter is required.', 'TBD' );
+		}
+
 		$cap = apply_filters( 'pmpro_approvals_cap', 'pmpro_approvals' );
 
 		if ( current_user_can( 'edit_users' ) && ! empty( $user->ID ) ) {
@@ -1271,7 +1282,11 @@ class PMPro_Approvals {
 		}
 
 		if ( current_user_can( $cap ) && ! empty( $user->ID ) ) {
-			$actions[] = '<a href="' . admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $user->ID ) . '">View</a>';
+			if ( empty( $approval_user ) ) {
+				$actions[] = '<a href="' . admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $user->ID ) . '">View</a>';
+			} else {
+				$actions[] = '<a href="' . admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $user->ID . '&l=' . $approval_user->membership_id ) . '">View</a>';
+			}
 		}
 
 		return $actions;
@@ -1281,19 +1296,23 @@ class PMPro_Approvals {
 	 * Add Approvals status to Account Page.
 	 */
 	public static function pmpro_account_bullets_top() {
-			$approval_status = ucfirst( self::getUserApprovalStatus() );
+		// Get all of the user's approval statuses.
+		$approval_statuses = self::getUserApprovalStatuses();
 
-			$user_level = pmpro_getMembershipLevelForUser();
-			if ( empty( $user_level ) ) {
-				return;
-			}
-			
-			$level_approval = self::requiresApproval( $user_level->ID );
+		// Get all levels that require approval.
+		$approval_levels = self::getApprovalLevels();
 
-			// Only show this if the user has an approval status.
-			if ( $level_approval ) {
-			  printf( '<li><strong>' . __( 'Status', 'pmpro-approvals' ) . ':' . '</strong> %s</li>', $approval_status );
+		// Display approval status for each level that requires approval.
+		foreach ( $approval_levels as $approval_level_id ) {
+			// Check if we have an approval status.
+			if ( ! empty( $approval_statuses[ $approval_level_id ] ) ) {
+				// Check that the user has this level.
+				if ( self::hasMembershipLevelSansApproval( $approval_level_id ) ) {
+					$level = pmpro_getLevel( $approval_level_id );
+					printf( '<li><strong>' . esc_html( 'Approval Status for %s', 'pmpro-approvals' ) . ':' . '</strong> %s</li>', $level->name, $approval_statuses[ $approval_level_id ] );
+				}
 			}
+		}
 	}
 
 	/**
@@ -1310,9 +1329,13 @@ class PMPro_Approvals {
 		return $user;
 	}
 
-	// Show user status if the user is pending.
-	if ( current_user_can( 'pmpro_approvals' ) && self::isPending( $user->ID, $user->membership_id ) && ! in_array( $level_type, $status_in ) ) {
-		$user->membership .= ' (<a href="' . admin_url( 'admin.php?page=pmpro-approvals&s=' . urlencode( $user->user_email ) ) . '">' . __( 'Pending', 'pmpro-approvals' ) . '</a>)';
+	// Check if the user is pending for any of their levels.
+	$approval_levels = self::getApprovalLevels();
+	foreach ( $approval_levels as $approval_level_id ) {
+		if ( self::isPending( $user->ID, $approval_level_id ) ) {
+			$user->membership .= ' (<a href="' . admin_url( 'admin.php?page=pmpro-approvals&s=' . urlencode( $user->user_email ) ) . '">' . __( 'Pending', 'pmpro-approvals' ) . '</a>)';
+			break;
+		}
 	}
 
 	return $user;
@@ -1343,13 +1366,10 @@ class PMPro_Approvals {
 
 		global $current_user;
 
-		$approval_status = self::getUserApprovalStatus();
-
-		$users_level = pmpro_getMembershipLevelForUser( $current_user->ID );
-		$level_id    = $users_level->ID;
+		$approval_status = self::getUserApprovalStatus( $current_user->ID, $pmpro_invoice->membership_id );
 
 		//if current level does not require approval keep confirmation message the same.
-		if ( ! self::requiresApproval( $level_id ) ) {
+		if ( ! self::requiresApproval( $pmpro_invoice->membership_id ) ) {
 			return $confirmation_message;
 		}
 
@@ -1435,58 +1455,19 @@ class PMPro_Approvals {
 
 	//Approve members from edit profile in WordPress.
 	public static function show_user_profile_status( $user ) {
-
-		//get some info about the user's level
-		if ( isset( $_REQUEST['membership_level'] ) ) {
-			$level_id = intval( $_REQUEST['membership_level'] );
-			$level    = pmpro_getLevel( $level_id );
-		} else {
-			$level = pmpro_getMembershipLevelForUser( $user->ID );
-			if ( ! empty( $level ) ) {
-				$level_id = $level->id;
-			} else {
-				$level_id = null;
-			}
-		}
-
-		//process any approve/deny/reset click
-		if ( current_user_can( 'pmpro_approvals' ) ) {
-			if ( ! empty( $_REQUEST['approve'] ) ) {
-				self::approveMember( intval( $_REQUEST['approve'] ), $level_id );
-			} elseif ( ! empty( $_REQUEST['deny'] ) ) {
-				self::denyMember( intval( $_REQUEST['deny'] ), $level_id );
-			} elseif ( ! empty( $_REQUEST['unapprove'] ) ) {
-				self::resetMember( intval( $_REQUEST['unapprove'] ), $level_id );
-			}
-		}
-
 		//show info
 		?>
 		<table id="pmpro_approvals_status_table" class="form-table">
 			<tr>
-				<th><?php esc_html_e( 'Approval Status', 'pmpro-approvals' ); ?></th>
-
+				<th><?php esc_html_e( 'Approval Statuses', 'pmpro-approvals' ); ?></th>
 				<td>
-					<span id="pmpro_approvals_status_text">
-						<?php echo self::getUserApprovalStatus( $user->ID, null, false ); ?>
-					</span>
-					<?php if ( current_user_can( 'pmpro_approvals' ) ) { ?>
-					<span id="pmpro_approvals_reset_link" 
 					<?php
-					if ( self::isPending( $user->ID, $level_id ) ) {
-?>
-style="display: none;"<?php } ?>>
-						[<a href="javascript:askfirst('Are you sure you want to reset approval for <?php echo $user->user_login; ?>?', '?&user_id=<?php echo $user->ID; ?>&unapprove=<?php echo $user->ID; ?>');">X</a>]
-					</span>
-					<span id="pmpro_approvals_approve_deny_links" 
-					<?php
-					if ( ! self::isPending( $user->ID, $level_id ) ) {
-?>
-style="display: none;"<?php } ?>>
-						<a href="?user_id=<?php echo $user->ID; ?>&approve=<?php echo $user->ID; ?>">Approve</a> |
-						<a href="?user_id=<?php echo $user->ID; ?>&deny=<?php echo $user->ID; ?>">Deny</a>
-					</span>
-					<?php } ?>
+					// Link to the approvals admin page for this user.
+					$approvals_admin_url = admin_url( 'admin.php?page=pmpro-approvals&s=' . esc_url( $user->nickname ) . '&status=all' );
+					?>
+					<p>
+						<a href="<?php echo esc_url( $approvals_admin_url ); ?>"><?php esc_html_e( 'Manage Approval Statuses', 'pmpro-approvals' ); ?></a>
+					</p>
 				</td>
 			</tr>
 			<?php
@@ -1504,58 +1485,6 @@ style="display: none;"<?php } ?>>
 
 			<?php } ?>
 		</table>
-		<script>
-			var pmpro_approval_levels = <?php echo json_encode( self::getApprovalLevels() ); ?>;
-			var pmpro_approval_user_status_per_level = <?php echo json_encode( self::getUserApprovalStatuses( $user->ID, true ) ); ?>;
-			var pmpro_approval_user_status_full_per_level = <?php echo json_encode( self::getUserApprovalStatuses( $user->ID ) ); ?>;
-			
-			function pmpro_approval_updateApprovalStatus() {
-				//get the level from the dropdown
-				var olevel = <?php echo json_encode( $level_id ); ?>;
-				var level = jQuery('[name=membership_level]').val();
-				
-				//no level field, default to the user's level id
-				if(typeof(level) === 'undefined')
-					level = olevel;
-				
-				//if no level, hide it
-				if(level == '') {
-					//no level, so hide everything
-					jQuery('#pmpro_approvals_status_table').hide();
-				} else if(pmpro_approval_levels.indexOf(parseInt(level)) < 0) {
-					//show the field, but hide the actions
-					jQuery('#pmpro_approvals_reset_link').hide();
-					jQuery('#pmpro_approvals_approve_deny_links').hide();
-					
-					jQuery('#pmpro_approvals_status_text').html(<?php echo json_encode( __( 'The chosen level does not require approval.', 'pmpro-approvals' ) ); ?>);
-					
-					jQuery('#pmpro_approvals_status_table').show();
-				} else {
-					//show the status and action links
-					jQuery('#pmpro_approvals_status_text').html(pmpro_approval_user_status_full_per_level[level]);
-					jQuery('#pmpro_approvals_status_table').show();
-					
-					if(level == olevel) {
-						if(pmpro_approval_user_status_per_level[level] == 'pending') {
-							jQuery('#pmpro_approvals_reset_link').hide();
-							jQuery('#pmpro_approvals_approve_deny_links').show();
-						} else {
-							jQuery('#pmpro_approvals_reset_link').show();
-							jQuery('#pmpro_approvals_approve_deny_links').hide();
-						}
-					} else {
-						jQuery('#pmpro_approvals_reset_link').hide();
-						jQuery('#pmpro_approvals_approve_deny_links').hide();
-					}
-				}				
-			}
-			
-			//update approval status when the membership level select changes
-			jQuery('[name=membership_level]').change(function(){pmpro_approval_updateApprovalStatus();});
-			
-			//call this once on load just in case
-			pmpro_approval_updateApprovalStatus();
-		</script>
 		<?php
 	}
 
@@ -1567,6 +1496,7 @@ style="display: none;"<?php } ?>>
 
 		// try to get the current user level.
 		if ( empty( $level_id ) ) {
+			_doing_it_wrong( __FUNCTION__, 'The $level_id parameter is required.', 'TBD' );
 			$user_level = pmpro_getMembershipLevelForUser( $user_id );
 			$level_id   = $user_level->id;
 		}
@@ -1846,35 +1776,6 @@ style="display: none;"<?php } ?>>
 
 		load_plugin_textdomain( 'pmpro-approvals', false, basename( dirname( __FILE__ ) ) . '/languages' );
 	}
-
-	/**
-	 * Change "Your Level" to "Awaiting Approval" in these instances for pending users. 
-	 * @since 1.3
-	 */
-	public static function change_your_level_text( $translated_text, $text, $domain ) {
-		global $current_user;
-
-		$approved = self::isApproved( $current_user->ID );
-
-		// Bail if the user is approved.
-		if ( $approved ) {
-			return $translated_text;
-		}
-
-		$approval = self::getUserApproval( $current_user->ID );
-
-		if ( $domain == 'paid-memberships-pro' ) {
-			if ( $translated_text == 'Your&nbsp;Level' ) {
-				if ( $approval['status'] == 'pending' ){
-					$translated_text = __( 'Pending Approval', 'pmpro-approvals' );
-				} else {
-					$translated_text = __( 'Membership Denied', 'pmpro-approvals' );
-				}
-			}
-		}
-		return $translated_text;
-	}
-
 
 } // end class
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Add compatibility with PMPro Multiple Memberships Per User. Note that this does not include compatibility for purchasing multiple levels in a single checkout, only for managing users who have multiple levels.

Specific changes made include:
- Fixing the Approvals Admin page
- Updating emails to pull information about the specific level being approved/denied
- Updating Account page to show approval status for all approval levels that the user has
- Updating functions  with `level` as an optional parameter to throw a "doing it wrong" warning
- Removing approving/denying users directly from the edit user page. Instead, now shows a link to the approvals admin page
- Removed code that shows "pending" and "denied" levels on the Levels page. This would be nice to add back, but it is not currently possible to get the level being shown in the `gettext` filter. Hopefully we can find a way to add this back in a future update

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #143 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.