### PR TITLE
allow filtering of email template

### DIFF
--- a/classes/class.approvalemails.php
+++ b/classes/class.approvalemails.php
@@ -55,6 +55,19 @@ class PMPro_Approvals_Email extends PMProEmail {
 		$this->from     = get_option( 'pmpro_from' );
 		$this->fromname = get_option( 'pmpro_from_name' );
 
+		/**
+		 * Filters the email template.
+		 *
+		 * This filter allows modification of the email template before it is rendered.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $message The custom message content.
+		 * @param WP_User $member The recipient of the email.
+		 * @param stdClass $level The level of the recipient.
+		 */
+		$this->template = apply_filters( 'pmpro_approvals_member_approved_email_template', $this->template, $member, $level );
+
 		$this->data = apply_filters( 'pmpro_approvals_member_approved_email_data', $this->data, $member, $level );
 
 		return $this->sendEmail();
@@ -97,6 +110,19 @@ class PMPro_Approvals_Email extends PMProEmail {
 		);
 		$this->from     = get_option( 'pmpro_from' );
 		$this->fromname = get_option( 'pmpro_from_name' );
+
+		/**
+		 * Filters the email template.
+		 *
+		 * This filter allows modification of the email template before it is rendered.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $message The custom message content.
+		 * @param WP_User $member The recipient of the email.
+		 * @param stdClass $level The level of the recipient.
+		 */
+		$this->template = apply_filters( 'pmpro_approvals_member_denied_email_template', $this->template, $member, $level );
 
 		$this->data = apply_filters( 'pmpro_approvals_member_denied_email_data', $this->data, $member, $level );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changelog entry

ENHANCEMENT: Added the `pmpro_approvals_member_approved_email_template` and `pmpro_approvals_member_denied_email_template` filters. 

These be used in conjunction with the `pmproet_templates` filter to create new templates in the PMP email templates screen and dynamically apply them to emails depending on - for example - the user level.