### PR TITLE
Updating the "no access" message for 3.1

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -1316,9 +1316,9 @@ class PMPro_Approvals {
 				}
 
 				if ( self::isPending( $current_user->ID, $user_level->id ) ) {
-					return esc_html__( 'Your membership requires approval before you are able to view this content.', 'pmpro-approvals' );
+					return '<p>' . esc_html__( 'Your membership requires approval before you are able to view this content.', 'pmpro-approvals' ) . '</p>';
 				} elseif ( self::isDenied( $current_user->ID, $user_level->id ) ) {
-					return esc_html__( 'Your membership application has been denied. Contact the site owners if you believe this is an error.', 'pmpro-approvals' );
+					return '<p>' . esc_html__( 'Your membership application has been denied. Contact the site owners if you believe this is an error.', 'pmpro-approvals' ) . '</p>';
 				}
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Updating the "no access" message UI for PMPro v3.1 and avoiding deprecated filters.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.