### PR TITLE
Fix admin email PHP warnings

### DIFF
--- a/classes/class.approvalemails.php
+++ b/classes/class.approvalemails.php
@@ -183,8 +183,8 @@ class PMPro_Approvals_Email extends PMProEmail {
 		$this->body     = file_get_contents( PMPRO_APP_DIR . '/email/admin_approved.html' );
 		$this->data     = array(
 			'subject'    => $this->subject,
-			'name'       => $admin->display_name,
-			'user_login' => $admin->user_login,
+			'name'       => isset( $admin->display_name ) ? $admin->display_name : "",
+			'user_login' => isset( $admin->user_login ) ? $admin->user_login : "",
 			'sitename'   => get_option( 'blogname' ),
 			'siteemail'  => get_option( 'pmpro_from_email' ),
 			'login_link' => wp_login_url(),
@@ -240,8 +240,8 @@ class PMPro_Approvals_Email extends PMProEmail {
 		$this->body     = file_get_contents( PMPRO_APP_DIR . '/email/admin_denied.html' );
 		$this->data     = array(
 			'subject'    => $this->subject,
-			'name'       => $admin->display_name,
-			'user_login' => $admin->user_login,
+			'name'       => isset( $admin->display_name ) ? $admin->display_name : "",
+			'user_login' => isset( $admin->user_login ) ? $admin->user_login : "",
 			'sitename'   => get_option( 'blogname' ),
 			'siteemail'  => get_option( 'pmpro_from_email' ),
 			'login_link' => wp_login_url(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Resolve PHP warnings that can occur when the site administrator email isn't associated with a WordPress user account