### PR TITLE
Always use the user's real levels in the admin

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -574,16 +574,9 @@ class PMPro_Approvals {
 			return $haslevel;
 		}
 
-		// Only check this inside admin of WordPress.
-		if ( is_admin() && function_exists( 'get_current_screen' ) ) {
-
-			// Ignore if on the edit user screen. This will allow admins/users to update custom fields.
-			$current_screen = get_current_screen();
-			
-			if ( !empty( $current_screen ) && ( $current_screen->base == 'user-edit' || $current_screen->base == 'profile' ) ) {
-				return $haslevel;
-			}
-
+		// Show the real levels in the admin.
+		if ( is_admin() ) {
+			return $haslevel;
 		}
 
 		//no user, skip
@@ -597,7 +590,7 @@ class PMPro_Approvals {
 		}
 
 		// If the current user doesn't have a level, bail.
-		if ( ! pmpro_hasMembershipLevel() ) {
+		if ( ! pmpro_hasMembershipLevel( null, $user_id ) ) {
 			return $haslevel;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes conflict with Pay By Check if user fields are restricted by level.

Previously, these user fields would not be saved when an admin changes the order from `pending` to `success`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.