### PR TITLE
Fixing pmpro_has_membership_level() without specifying level (and other edge cases)

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -544,16 +544,13 @@ class PMPro_Approvals {
 			return $access;
 		}
 
-		// If no levels are defined Let's set this to false. isApproved cannot be called without level.
-		if ( empty( $levels ) ) {
+		// If no levels are defined but they aren't approved. Let's set this to false.
+		if ( empty( $levels ) && ! self::isApproved( $current_user->ID ) ) {
 			return false;
 		}
 
-		foreach ( $levels as $level ) {
-			if( self::isApproved( $current_user->ID, $level ) ) {
-				return $access;
-				break;
-			}
+		if ( self::isApproved( $current_user->ID ) ) {
+			return $access;
 		}
 
 		return $access;
@@ -664,7 +661,6 @@ class PMPro_Approvals {
 		if ( ! empty( $user_id ) ) {
 			//default to the user's current level
 			if ( empty( $level_id ) ) {
-				_doing_it_wrong( __FUNCTION__, __( 'You should pass a level ID to getUserApproval.', 'pmpro-approvals' ), '1.5' );
 				$level = pmpro_getMembershipLevelForUser( $user_id );
 				if ( ! empty( $level ) ) {
 					$level_id = $level->id;
@@ -792,10 +788,6 @@ class PMPro_Approvals {
 	 * Check if a user is approved.
 	 */
 	public static function isApproved( $user_id = null, $level_id = null ) {
-		//Bail if thre's no level ID. Otherwise it throws an error in  self::getUserApproval( $user_id, $level_id );
-		if ( empty( $level_id ) ) {
-			return false;
-		}
 		//default to the current user
 		if ( empty( $user_id ) ) {
 			global $current_user;

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -544,15 +544,18 @@ class PMPro_Approvals {
 			return $access;
 		}
 
-		// If no levels are defined but they aren't approved. Let's set this to false.
-		if ( empty( $levels ) && ! self::isApproved( $current_user->ID ) ) {
+		// If no levels are defined Let's set this to false. isApproved cannot be called without level.
+		if ( empty( $levels ) ) {
 			return false;
 		}
 
-		if ( self::isApproved( $current_user->ID ) ) {
-			return $access;
+		foreach ( $levels as $level ) {
+			if( self::isApproved( $current_user->ID, $level ) ) {
+				return $access;
+				break;
+			}
 		}
-		
+
 		return $access;
 	}
 
@@ -789,6 +792,10 @@ class PMPro_Approvals {
 	 * Check if a user is approved.
 	 */
 	public static function isApproved( $user_id = null, $level_id = null ) {
+		//Bail if thre's no level ID. Otherwise it throws an error in  self::getUserApproval( $user_id, $level_id );
+		if ( empty( $level_id ) ) {
+			return false;
+		}
 		//default to the current user
 		if ( empty( $user_id ) ) {
 			global $current_user;


### PR DESCRIPTION
Need to be merged taking into consideration this one -> https://github.com/strangerstudios/paid-memberships-pro/pull/3322


### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:
 Remove hook to deprecated `pmpro_member_shortcode_access` filter
* Deprecate filter callback function `pmpro_member_shortcode_access`
* Restore `_doing_it_wrong` function call removed in a previous commit.
* Add several unhandled cases to `pmpro_has_membership_level` filter callback and removed not safe checks to better handle empty levels and other cases.
### How to test the changes in this Pull Request:

1. Add a membership short code without a level to a page. [membership] some content [/membership]
2. Without this patch, you'll see and error in debug.log  with message `You should pass a level ID to getUserApproval.`
3. With the patch, the deprecated hook won't call getUserApproval then wont throw the error.
4. It's needed to check that the protected content still work the expected way.

Add below to wp-config.php file
define('WP_DEBUG', true);
define('WP_DEBUG_LOG', true);
define('WP_DEBUG_DISPLAY', false);
@ini_set('display_errors', 0);

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.