### PR TITLE
[bugfixing] Evaluate $membership before display message because some …

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -1445,7 +1445,7 @@ class PMPro_Approvals {
 		}
 
 		$membership_name = $membership ? $membership->name : '';
-		$confirmation_message = '<p>' . sprintf( __( 'Thank you for your membership to %1$s. Your %2$s membership status is: <b>%3$s</b>.', 'pmpro-approvals' ), get_bloginfo( 'name' ),$membership_name, $approval_status ) . '</p>';
+		$confirmation_message = '<p>' . sprintf( __( 'Thank you for your membership to %1$s. Your %2$s membership status is: <b>%3$s</b>.', 'pmpro-approvals' ), get_bloginfo( 'name' ), $membership_name, $approval_status ) . '</p>';
 
 		// Check instructions. $pmpro_invoice should not be empty when reaching here.
 		if ( ! empty( $pmpro_invoice ) && $pmpro_invoice->gateway == "check" && ! pmpro_isLevelFree( $pmpro_invoice->membership_level ) ) {

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -1444,7 +1444,8 @@ class PMPro_Approvals {
 			$approval_status = __( 'pending', 'pmpro-approvals' );
 		}
 
-		$confirmation_message = '<p>' . sprintf( __( 'Thank you for your membership to %1$s. Your %2$s membership status is: <b>%3$s</b>.', 'pmpro-approvals' ), get_bloginfo( 'name' ), $membership->name, $approval_status ) . '</p>';
+		$membership_name = $membership ? $membership->name : '';
+		$confirmation_message = '<p>' . sprintf( __( 'Thank you for your membership to %1$s. Your %2$s membership status is: <b>%3$s</b>.', 'pmpro-approvals' ), get_bloginfo( 'name' ),$membership_name, $approval_status ) . '</p>';
 
 		// Check instructions. $pmpro_invoice should not be empty when reaching here.
 		if ( ! empty( $pmpro_invoice ) && $pmpro_invoice->gateway == "check" && ! pmpro_isLevelFree( $pmpro_invoice->membership_level ) ) {


### PR DESCRIPTION
…times is false.


![image](https://github.com/user-attachments/assets/81388cbc-2d91-430b-9a62-223107f4bd0c)

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Evaluate $membership before display confirmation message to see if it's not false.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.