### PR TITLE
[BUGFIXING] When get_transient( 'pmpro_approvals_approval_count' ) re…

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -1686,10 +1686,10 @@ class PMPro_Approvals {
 		}
 
 		// Check for a cached value in the transient.
-		$number_of_users = get_transient( 'pmpro_approvals_approval_count' );	
+		$number_of_users = get_transient( 'pmpro_approvals_approval_count' );
 		
-		// Store results in an array to support different statuses.
-		if ( ! isset( $number_of_users ) ) {
+		// If get_transient above returns false, set to an empty array.
+		if ( ! $number_of_users ) {
 			$number_of_users = array();
 		}
 		


### PR DESCRIPTION
…turns false a warning is logged in the debug.log file

 * Change ! isset validation to create the empty array when $number_of_users is false.
<img width="1402" alt="Screenshot 2025-02-20 at 7 06 20 PM" src="https://github.com/user-attachments/assets/d79ab195-12cd-4818-a8cc-84397504773c" />


### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

If the transient does not exist, does not have a value, or has expired, then the return value will be false check for a boolean instead of null.

### How to test the changes in this Pull Request:

1. Config a level to require approval
2. Checkout that level with a new user
3. Go to approvals page
4. Check debug.log

Add below to wp-config.php file
define('WP_DEBUG', true);
define('WP_DEBUG_LOG', true);
define('WP_DEBUG_DISPLAY', false);
@ini_set('display_errors', 0);

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.