### PR TITLE
Fix for database errors that occur if no levels require approval

### DIFF
--- a/adminpages/approvals.php
+++ b/adminpages/approvals.php
@@ -90,13 +90,13 @@ if ( ! empty( $_REQUEST['approve'] ) ) {
 		<input class="button" type="submit" value="<?php _e( 'Search Approvals', 'pmpro-approvals' ); ?>"/>
 	</p>
 	<div class="tablenav top">	
-		<?php _e( 'Show', 'pmpro-approvals' ); ?> 
+		<?php esc_html_e( 'Show', 'pmpro-approvals' ); ?> 
 		<select name="l" onchange="jQuery('#posts-filter').submit();">
 			<option value="" 
 				<?php if ( ! $l ) { ?>
 					selected="selected"
 				<?php } ?>>
-				<?php _e( 'All Levels', 'pmpro-approvals' ); ?>
+				<?php esc_html_e( 'All Levels', 'pmpro-approvals' ); ?>
 			</option>
 			<?php
 				$approval_level_ids = PMPro_Approvals::getApprovalLevels();

--- a/adminpages/approvals.php
+++ b/adminpages/approvals.php
@@ -90,26 +90,31 @@ if ( ! empty( $_REQUEST['approve'] ) ) {
 		<input class="button" type="submit" value="<?php _e( 'Search Approvals', 'pmpro-approvals' ); ?>"/>
 	</p>
 	<div class="tablenav top">	
-		<?php _e( 'Show', 'pmpro-approvals' ); ?> <select name="l" onchange="jQuery('#posts-filter').submit();">
-		<option value="" 
-		<?php
-		if ( ! $l ) {
-?>
-selected="selected"<?php } ?>><?php _e( 'All Levels', 'pmpro-approvals' ); ?></option>
-		<?php
-			$approval_level_ids = PMPro_Approvals::getApprovalLevels();
-			$levels             = $wpdb->get_results( "SELECT id, name FROM $wpdb->pmpro_membership_levels WHERE id IN(" . implode( ',', $approval_level_ids ) . ') ORDER BY name' );
-		foreach ( $levels as $level ) {
-		?>
-		<option value="<?php echo $level->id; ?>" 
-									<?php
-									if ( $l == $level->id ) {
-							?>
-							selected="selected"<?php } ?>><?php echo $level->name; ?></option>
-		<?php
-		}
-		?>
-	</select>
+		<?php _e( 'Show', 'pmpro-approvals' ); ?> 
+		<select name="l" onchange="jQuery('#posts-filter').submit();">
+			<option value="" 
+				<?php if ( ! $l ) { ?>
+					selected="selected"
+				<?php } ?>>
+				<?php _e( 'All Levels', 'pmpro-approvals' ); ?>
+			</option>
+			<?php
+				$approval_level_ids = PMPro_Approvals::getApprovalLevels();
+				if ( ! empty( $approval_level_ids ) ) {
+					$levels = $wpdb->get_results( "SELECT id, name FROM $wpdb->pmpro_membership_levels WHERE id IN(" . implode( ',', $approval_level_ids ) . ') ORDER BY name' );
+					foreach ( $levels as $level ) {
+						?>
+						<option value="<?php echo $level->id; ?>" 
+							<?php if ( $l == $level->id ) { ?>
+								selected="selected"
+							<?php } ?>>
+							<?php echo $level->name; ?>
+						</option>
+					<?php
+					}
+				}
+			?>
+		</select>
 	</div>
 	<?php
 		//some vars for the search
@@ -272,3 +277,4 @@ class="alternate"<?php } ?>>
 <?php
 	require_once PMPRO_DIR . '/adminpages/admin_footer.php';
 ?>
+

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -925,6 +925,11 @@ class PMPro_Approvals {
 	public static function getApprovals( $l = false, $s = '', $status = 'pending', $sortby = 'user_registered', $sortorder = 'ASC', $pn = 1, $limit = 15 ) {
 		global $wpdb;
 
+		$approval_levels = self::getApprovalLevels();
+		if ( empty( $approval_levels ) ) {
+			return array();
+		}
+
 		$end   = $pn * $limit;
 		$start = $end - $limit;
 
@@ -946,7 +951,7 @@ class PMPro_Approvals {
 		if ( $l ) {
 			$sql_parts['WHERE'] .= "AND mu.membership_id = '" . esc_sql( $l ) . "' ";
 		} else {
-			$sql_parts['WHERE'] .= "AND mu.membership_id IN(" . implode( ',', self::getApprovalLevels() ) . ") ";
+			$sql_parts['WHERE'] .= "AND mu.membership_id IN(" . implode( ',', $approval_levels ) . ") ";
 		}
 
 		if ( ! empty( $status ) && $status != 'all' ) {
@@ -1719,6 +1724,12 @@ class PMPro_Approvals {
 		if ( ! isset( $number_of_users[$approval_status] ) ) {
 
 			$approval_levels = self::get_all_approval_level_ids(); // Get level ID's that require approvals only and search against those.
+
+			// return 0 if no levels require approval.
+			if ( empty( $approval_levels ) ) {
+				$number_of_users[$approval_status] = 0;
+				return $number_of_users[$approval_status];
+			}
 
 			$sql_parts = array();
 			$sql_parts['SELECT'] = "SELECT COUNT(mu.user_id) as count FROM $wpdb->pmpro_memberships_users mu ";


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Prevents database errors that occur on Approvals admin pages when no levels require approval.
Some WPCS changes.

Closes: #202

### How to test the changes in this Pull Request:

1. Enable error logging.
2. Ensure none of your levels require approval.
3. Visit Approvals admin pages.
4. Observe that no database errors are logged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->