### PR TITLE
Fix Default Recipient label for admin emails

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-approved.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-approved.php
@@ -44,7 +44,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Approved extends PMPro_Email_Tem
 	 * @return string The email template slug.
 	 */
 	public static function get_template_slug() {
-		return 'admin_approved';
+		return 'admin_approved_admin';
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-approved.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-approved.php
@@ -170,7 +170,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Approved extends PMPro_Email_Tem
  * @return array The modified email templates array.
  */
 function pmpro_email_template_pmpro_approval_admin_approved( $email_templates ) {
-	$email_templates['admin_approved'] = 'PMPro_Email_Template_PMProApprovals_Admin_Approved';
+	$email_templates['admin_approved_admin'] = 'PMPro_Email_Template_PMProApprovals_Admin_Approved';
 	return $email_templates;
 }
 add_filter( 'pmpro_email_templates', 'pmpro_email_template_pmpro_approval_admin_approved' );

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-denied.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-denied.php
@@ -171,7 +171,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Denied extends PMPro_Email_Templ
  * @return array The modified email templates array.
  */
 function pmpro_email_template_pmpro_approval_admin_denied( $email_templates ) {
-	$email_templates['admin_denied'] = 'PMPro_Email_Template_PMProApprovals_Admin_Denied';
+	$email_templates['admin_denied_admin'] = 'PMPro_Email_Template_PMProApprovals_Admin_Denied';
 	return $email_templates;
 }
 add_filter( 'pmpro_email_templates', 'pmpro_email_template_pmpro_approval_admin_denied' );

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-denied.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-denied.php
@@ -45,7 +45,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Denied extends PMPro_Email_Templ
 	 * @return string The email template slug.
 	 */
 	public static function get_template_slug() {
-		return 'admin_denied';
+		return 'admin_denied_admin';
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-notification-approval.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-notification-approval.php
@@ -45,7 +45,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval extends PM
 	 * @return string The email template slug.
 	 */
 	public static function get_template_slug() {
-		return 'admin_notification_approval';
+		return 'admin_notification_approval_admin';
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-notification-approval.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-notification-approval.php
@@ -173,7 +173,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval extends PM
  * @return array The modified email templates array.
  */
 function pmpro_email_template_pmpro_approvals_admin_notification_approval( $email_templates ) {
-	$email_templates['admin_notification_approval'] = 'PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval';
+	$email_templates['admin_notification_approval_admin'] = 'PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval';
 	return $email_templates;
 }
 add_filter( 'pmpro_email_templates', 'pmpro_email_template_pmpro_approvals_admin_notification_approval' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Add `_admin` suffix to the admin email template keys. 

Resolves #205 

### How to test the changes in this Pull Request:
1. Navigate to _Memberships > Settings > Email Templates_.
2. Check the _Default Recipient_ column values for the _Approval Approved (admin)_, _Approval Denied (admin)_, and _Approval Pending (admin)_ email templates.

![image](https://github.com/user-attachments/assets/4b7d94de-5a89-49a5-8694-9d32e3185fda)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed incorrect recipient labels on the Email Templates admin screen.