### PR TITLE
Restrict Member Directory and Profile when pending

### DIFF
--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -567,6 +567,10 @@ class PMPro_Approvals {
 	public static function pmpro_has_membership_level( $haslevel, $user_id, $levels ) {
 		global $pmpro_pages;
 
+		// Remove this from the global, because we may want to restrict the directory and profile pages.
+		unset( $pmpro_pages['directory'] );
+		unset( $pmpro_pages['profile'] );
+		
 		// Let members access PMPro pages, PMPro can handle the cases here.
 		if ( is_page( $pmpro_pages ) ) {
 			return $haslevel;

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -567,12 +567,15 @@ class PMPro_Approvals {
 	public static function pmpro_has_membership_level( $haslevel, $user_id, $levels ) {
 		global $pmpro_pages;
 
-		// Remove this from the global, because we may want to restrict the directory and profile pages.
-		unset( $pmpro_pages['directory'] );
-		unset( $pmpro_pages['profile'] );
+		// Create a local copy of the global $pmpro_pages array.
+		$allowed_pages = $pmpro_pages;
+
+		// Remove these pages from the local copy, because we may want to restrict the directory and profile pages.
+		unset( $allowed_pages['directory'] );
+		unset( $allowed_pages['profile'] );
 		
 		// Let members access PMPro pages, PMPro can handle the cases here.
-		if ( is_page( $pmpro_pages ) ) {
+		if ( is_page( $allowed_pages ) ) {
 			return $haslevel;
 		}
 


### PR DESCRIPTION
* BUG FIX: Fixed an issue where Directory pages would not be restricted if pending approval or denied.

Resolves: https://github.com/strangerstudios/pmpro-approvals/issues/211

Prior to this logic, we assumed that all generated PMPro pages should be accessible even if denied or awaiting approval which makes sense for the default PMPro pages generated by core. However, the Membership Directory and Profile pages are often premium features for members to access and view which is why this change has been made to always honor content restriction for the directory and profile pages.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?