### PR TITLE
Fix issue for admin emails when the admin isn't a WP user

### DIFF
--- a/classes/class.approvalemails.php
+++ b/classes/class.approvalemails.php
@@ -153,7 +153,7 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$level = pmpro_getSpecificMembershipLevelForUser( $member->ID, $level_id );
 		}
 
-		// Use the new email templates if the are available.
+		// Use the new email templates if they are available.
 		if ( class_exists( 'PMPro_Email_Template' ) ) {
 			$send_admin_pending_email = new PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval( $member, $level );
 			return $send_admin_pending_email->send();
@@ -233,7 +233,7 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$level = pmpro_getSpecificMembershipLevelForUser( $member->ID, $level_id );
 		}
 
-		// Use the new email templates if the are available.
+		// Use the new email templates if they are available.
 		if ( class_exists( 'PMPro_Email_Template' ) ) {
 			$send_member_approved_email = new PMPro_Email_Template_PMProApprovals_Admin_Approved( $member, $level );
 			return $send_member_approved_email->send();
@@ -314,9 +314,9 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$level = pmpro_getSpecificMembershipLevelForUser( $member->ID, $level_id );
 		}
 
-		// Use the new email templates if the are available.
+		// Use the new email templates if they are available.
 		if ( class_exists( 'PMPro_Email_Template' ) ) {
-			$send_member_denied_email = new PMPro_Email_Template_PMProApprovals_Admin_Denied( $member, $admin, $level );
+			$send_member_denied_email = new PMPro_Email_Template_PMProApprovals_Admin_Denied( $member, $level );
 			return $send_member_denied_email->send();
 		}
 

--- a/classes/class.approvalemails.php
+++ b/classes/class.approvalemails.php
@@ -30,6 +30,11 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$member = get_user_by( 'ID', $member );
 		}
 
+		// Bail if the member couldn't be found.
+		if ( ! $member ) {
+			return false;
+		}
+
 		if ( empty( $level_id ) ) {
 			$level = pmpro_getMembershipLevelForUser( $member->ID );
 		} else {
@@ -78,6 +83,11 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$member = get_user_by( 'ID', $member );
 		}
 
+		// Bail if the member couldn't be found.
+		if ( ! $member ) {
+			return false;
+		}
+
 		if ( empty( $level_id ) ) {
 			$level = pmpro_getMembershipLevelForUser( $member->ID );
 		} else {
@@ -88,6 +98,8 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$send_member_denied_email = new PMPro_Email_Template_PMProApprovals_Application_Denied( $member, $level );
 			return $send_member_denied_email->send();
 		}
+
+		// ---- Legacy email logic ----
 
 		$this->email    = $member->user_email;
 		$this->subject  = sprintf( __( 'Your membership at %s has been denied.', 'pmpro-approvals' ), get_bloginfo( 'name' ) );
@@ -135,6 +147,20 @@ class PMPro_Approvals_Email extends PMProEmail {
 			return false;
 		}
 
+		if ( empty( $level_id ) ) {
+			$level = pmpro_getMembershipLevelForUser( $member->ID );
+		} else {
+			$level = pmpro_getSpecificMembershipLevelForUser( $member->ID, $level_id );
+		}
+
+		// Use the new email templates if the are available.
+		if ( class_exists( 'PMPro_Email_Template' ) ) {
+			$send_admin_pending_email = new PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval( $member, $level );
+			return $send_admin_pending_email->send();
+		}
+
+		// ---- Legacy email logic ----
+
 		if ( empty( $admin ) ) {
 			$admin = get_user_by( 'email', get_option( 'admin_email' ) );
 		} elseif ( is_int( $admin ) ) {
@@ -147,17 +173,6 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$admin->user_email = get_bloginfo( 'admin_email' );
 			$admin->display_name = esc_html__( 'Admin', 'pmpro-approvals' );
 			$admin->user_login = '';
-		}
-
-		if ( empty( $level_id ) ) {
-			$level = pmpro_getMembershipLevelForUser( $member->ID );
-		} else {
-			$level = pmpro_getSpecificMembershipLevelForUser( $member->ID, $level_id );
-		}
-
-		if ( class_exists( 'PMPro_Email_Template' ) ) {
-			$send_admin_pending_email = new PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval( $member, $admin, $level );
-			return $send_admin_pending_email->send();
 		}
 
 		$this->email    = get_bloginfo( 'admin_email' );
@@ -212,6 +227,20 @@ class PMPro_Approvals_Email extends PMProEmail {
 			return false;
 		}
 
+		if ( empty( $level_id ) ) {
+			$level = pmpro_getMembershipLevelForUser( $member->ID );
+		} else {
+			$level = pmpro_getSpecificMembershipLevelForUser( $member->ID, $level_id );
+		}
+
+		// Use the new email templates if the are available.
+		if ( class_exists( 'PMPro_Email_Template' ) ) {
+			$send_member_approved_email = new PMPro_Email_Template_PMProApprovals_Admin_Approved( $member, $level );
+			return $send_member_approved_email->send();
+		}
+		
+		// ---- Legacy email logic ----
+
 		//Same for admin
 		if ( empty( $admin ) ) {
 			$admin = get_user_by( 'email', get_option( 'admin_email' ) );
@@ -227,16 +256,7 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$admin->user_login = '';
 		}
 
-		if ( empty( $level_id ) ) {
-			$level = pmpro_getMembershipLevelForUser( $member->ID );
-		} else {
-			$level = pmpro_getSpecificMembershipLevelForUser( $member->ID, $level_id );
-		}
-
-		if ( class_exists( 'PMPro_Email_Template' ) ) {
-			$send_member_approved_email = new PMPro_Email_Template_PMProApprovals_Admin_Approved( $member, $admin, $level );
-			return $send_member_approved_email->send();
-		}
+		
 
 		$this->email    = get_bloginfo( 'admin_email' );
 		$this->subject  = sprintf( __( 'A member at %s has been approved.', 'pmpro-approvals' ), get_bloginfo( 'name' ) );
@@ -288,6 +308,20 @@ class PMPro_Approvals_Email extends PMProEmail {
 			return false;
 		}
 
+		if ( empty( $level_id ) ) {
+			$level = pmpro_getMembershipLevelForUser( $member->ID );
+		} else {
+			$level = pmpro_getSpecificMembershipLevelForUser( $member->ID, $level_id );
+		}
+
+		// Use the new email templates if the are available.
+		if ( class_exists( 'PMPro_Email_Template' ) ) {
+			$send_member_denied_email = new PMPro_Email_Template_PMProApprovals_Admin_Denied( $member, $admin, $level );
+			return $send_member_denied_email->send();
+		}
+
+		// ---- Legacy email logic ----
+
 		//Same for admin
 		if ( empty( $admin ) ) {
 			$admin = get_user_by( 'email', get_option( 'admin_email' ) );
@@ -301,17 +335,6 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$admin->user_email = get_bloginfo( 'admin_email' );
 			$admin->display_name = esc_html__( 'Admin', 'pmpro-approvals' );
 			$admin->user_login = '';
-		}
-
-		if ( empty( $level_id ) ) {
-			$level = pmpro_getMembershipLevelForUser( $member->ID );
-		} else {
-			$level = pmpro_getSpecificMembershipLevelForUser( $member->ID, $level_id );
-		}
-
-		if ( class_exists( 'PMPro_Email_Template' ) ) {
-			$send_member_denied_email = new PMPro_Email_Template_PMProApprovals_Admin_Denied( $member, $admin, $level );
-			return $send_member_denied_email->send();
 		}
 
 		$this->email    = get_bloginfo( 'admin_email' );

--- a/classes/class.approvalemails.php
+++ b/classes/class.approvalemails.php
@@ -141,9 +141,12 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$admin = get_user_by( 'ID', $admin );
 		}
 
-		//Bail if couldn't find a user
+		//Default to the blog admin if the admin user cannot be found in WordPress.
 		if ( ! is_a( $admin, 'WP_User' ) ) {
-			return false;
+			$admin = new stdClass();
+			$admin->user_email = get_bloginfo( 'admin_email' );
+			$admin->display_name = esc_html__( 'Admin', 'pmpro-approvals' );
+			$admin->user_login = '';
 		}
 
 		if ( empty( $level_id ) ) {
@@ -216,9 +219,12 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$admin = get_user_by( 'ID', $admin );
 		}
 
-		//Bail if couldn't find a user
+		//Default to the blog admin if the admin user cannot be found in WordPress.
 		if ( ! is_a( $admin, 'WP_User' ) ) {
-			return false;
+			$admin = new stdClass();
+			$admin->user_email = get_bloginfo( 'admin_email' );
+			$admin->display_name = esc_html__( 'Admin', 'pmpro-approvals' );
+			$admin->user_login = '';
 		}
 
 		if ( empty( $level_id ) ) {
@@ -289,9 +295,12 @@ class PMPro_Approvals_Email extends PMProEmail {
 			$admin = get_user_by( 'ID', $admin );
 		}
 
-		//Bail if couldn't find a user
+		//Default to the blog admin if the admin user cannot be found in WordPress.
 		if ( ! is_a( $admin, 'WP_User' ) ) {
-			return false;
+			$admin = new stdClass();
+			$admin->user_email = get_bloginfo( 'admin_email' );
+			$admin->display_name = esc_html__( 'Admin', 'pmpro-approvals' );
+			$admin->user_login = '';
 		}
 
 		if ( empty( $level_id ) ) {

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-approved.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-approved.php
@@ -126,7 +126,18 @@ class PMPro_Email_Template_PMProApprovals_Admin_Approved extends PMPro_Email_Tem
 			'user_login' => $this->get_recipient_name()
 		);
 
-		return apply_filters( 'pmpro_approvals_admin_approved_email_data', $email_template_variables, $member, null );
+		// Preserve backward compatibility by passing an admin context object  
+        // (WP_User when available, or false otherwise) as the third argument.  
+        $admin_user  = false;  
+        $admin_email = $this->get_recipient_email();  
+        if ( ! empty( $admin_email ) && function_exists( 'is_email' ) && is_email( $admin_email ) ) {  
+            $resolved_admin = get_user_by( 'email', $admin_email );  
+            if ( $resolved_admin instanceof WP_User ) {  
+                $admin_user = $resolved_admin;  
+            }
+		}
+
+		return apply_filters( 'pmpro_approvals_admin_approved_email_data', $email_template_variables, $member, $admin_user );
 	}
 
 	/**
@@ -178,7 +189,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Approved extends PMPro_Email_Tem
 
 		$member = $random_user ? $random_user[0] : $current_user;	
 
-		return array( $member, $current_user, $pmpro_email_test_level );
+		return array( $member, $pmpro_email_test_level );
 	}
 }
 /**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-approved.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-approved.php
@@ -10,12 +10,6 @@ class PMPro_Email_Template_PMProApprovals_Admin_Approved extends PMPro_Email_Tem
 	protected $member;
 
 	/**
-	 * The admin user.
-	 *
-	 * @var WP_User
-	 */
-	protected $admin;
-	/**
 	 * The level object.
 	 *
 	 * @var StdClass
@@ -30,9 +24,8 @@ class PMPro_Email_Template_PMProApprovals_Admin_Approved extends PMPro_Email_Tem
 	 * @param WP_User $member The user applying for membership.
 	 * @param int $level_id The level id.
 	 */
-	public function __construct( WP_User $member, $admin = null, StdClass $level ) {
+	public function __construct( WP_User $member, StdClass $level ) {
 		$this->member = $member;
-		$this->admin = $admin;
 		$this->level = $level;
 	}
 
@@ -120,7 +113,6 @@ class PMPro_Email_Template_PMProApprovals_Admin_Approved extends PMPro_Email_Tem
 	public function get_email_template_variables() {
 		$level = $this->level;
 		$member = $this->member;
-		$admin = $this->admin;
 		$view_profile = admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $member->ID . '&l=' . $level->id );
 
 		$email_template_variables = array(
@@ -131,12 +123,10 @@ class PMPro_Email_Template_PMProApprovals_Admin_Approved extends PMPro_Email_Tem
 			'view_profile' => $view_profile,
 			'subject' => $this->get_default_subject(),
 			'name' => $this->get_recipient_name(),
-			'user_login' => isset( $admin->user_login ) ? $admin->user_login : "",
-
-
+			'user_login' => $this->get_recipient_name()
 		);
 
-		return apply_filters( 'pmpro_approvals_admin_approved_email_data', $email_template_variables, $member, $admin );
+		return apply_filters( 'pmpro_approvals_admin_approved_email_data', $email_template_variables, $member, null );
 	}
 
 	/**
@@ -147,7 +137,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Approved extends PMPro_Email_Tem
 	 * @return string The email address to send the email to.
 	 */
 	public function get_recipient_email() {
-		return ! empty( $this->admin->user_email ) ? $this->admin->user_email : get_bloginfo( 'admin_email' );
+		return get_bloginfo( 'admin_email' );
 	}
 
 	/**
@@ -158,7 +148,8 @@ class PMPro_Email_Template_PMProApprovals_Admin_Approved extends PMPro_Email_Tem
 	 * @return string The name of the email recipient.
 	 */
 	public function get_recipient_name() {
-		return empty( $this->admin->display_name ) ? esc_html__( 'Admin', 'pmpro-approvals' ) : $this->admin->display_name;
+		$user = get_user_by( 'email', $this->get_recipient_email() );
+		return empty( $user->display_name ) ? esc_html__( 'Admin', 'pmpro-approvals' ) : $user->display_name;
 	}
 
 	/**
@@ -167,7 +158,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Approved extends PMPro_Email_Tem
 	 * 
 	 * @since 1.6.5
 	 * 
-	 * @return array $test_data An array of contructor arguments (member, admin, level).
+	 * @return array $test_data An array of contructor arguments (member, level).
 	 */
 	public static function get_test_email_constructor_args() {
 		global $current_user, $pmpro_email_test_level;

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-approved.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-approved.php
@@ -30,7 +30,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Approved extends PMPro_Email_Tem
 	 * @param WP_User $member The user applying for membership.
 	 * @param int $level_id The level id.
 	 */
-	public function __construct( WP_User $member, WP_User $admin, StdClass $level ) {
+	public function __construct( WP_User $member, $admin = null, StdClass $level ) {
 		$this->member = $member;
 		$this->admin = $admin;
 		$this->level = $level;

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-denied.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-denied.php
@@ -9,12 +9,6 @@ class PMPro_Email_Template_PMProApprovals_Admin_Denied extends PMPro_Email_Templ
 	 */
 	protected $member;
 
-	/**
-	 * The admin user will receive the email.
-	 *
-	 * @var WP_User
-	 */
-	protected $admin;
 
 	/**
 	 * The level id
@@ -31,9 +25,8 @@ class PMPro_Email_Template_PMProApprovals_Admin_Denied extends PMPro_Email_Templ
 	 * @param WP_User $member The user applying for membership.
 	 * @param int $level_id The level id.
 	 */
-	public function __construct( WP_User $member, $admin = NULL, StdClass $level ) {
+	public function __construct( WP_User $member, StdClass $level ) {
 		$this->member = $member;
-		$this->admin = $admin;
 		$this->level = $level;
 	}
 
@@ -122,7 +115,6 @@ class PMPro_Email_Template_PMProApprovals_Admin_Denied extends PMPro_Email_Templ
 	public function get_email_template_variables() {
 		$level = $this->level;
 		$member = $this->member;
-		$admin = $this->admin;
 		$view_profile = admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $member->ID . '&l=' . $level->id );
 
 		$email_template_variables = array(
@@ -133,11 +125,10 @@ class PMPro_Email_Template_PMProApprovals_Admin_Denied extends PMPro_Email_Templ
 			'view_profile' => $view_profile,
 			'subject' => $this->get_default_subject(),
 			'name' => $this->get_recipient_name(),
-			'user_login' => isset( $admin->user_login ) ? $admin->user_login : "",
-
+			'user_login' => $this->get_recipient_name()
 		);
 
-		return apply_filters( 'pmpro_approvals_admin_denied_email_data', $email_template_variables, $member, $admin );
+		return apply_filters( 'pmpro_approvals_admin_denied_email_data', $email_template_variables, $member, null );
 	}
 
 	/**
@@ -148,7 +139,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Denied extends PMPro_Email_Templ
 	 * @return string The email address to send the email to.
 	 */
 	public function get_recipient_email() {
-		return ! empty( $this->admin->user_email ) ? $this->admin->user_email : get_bloginfo( 'admin_email' );
+		return get_bloginfo( 'admin_email' );
 	}
 
 	/**
@@ -159,7 +150,8 @@ class PMPro_Email_Template_PMProApprovals_Admin_Denied extends PMPro_Email_Templ
 	 * @return string The name of the email recipient.
 	 */
 	public function get_recipient_name() {
-		return empty( $this->admin->display_name ) ? esc_html__( 'Admin', 'pmpro-approvals' ) : $this->admin->display_name;
+		$user = get_user_by( 'email', $this->get_recipient_email() );
+		return empty( $user->display_name ) ? esc_html__( 'Admin', 'pmpro-approvals' ) : $user->display_name;
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-denied.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-denied.php
@@ -9,7 +9,6 @@ class PMPro_Email_Template_PMProApprovals_Admin_Denied extends PMPro_Email_Templ
 	 */
 	protected $member;
 
-
 	/**
 	 * The level id
 	 *
@@ -128,7 +127,18 @@ class PMPro_Email_Template_PMProApprovals_Admin_Denied extends PMPro_Email_Templ
 			'user_login' => $this->get_recipient_name()
 		);
 
-		return apply_filters( 'pmpro_approvals_admin_denied_email_data', $email_template_variables, $member, null );
+		// Preserve backward compatibility by passing an admin context object  
+        // (WP_User when available, or false otherwise) as the third argument.  
+        $admin_user  = false;  
+        $admin_email = $this->get_recipient_email();  
+        if ( ! empty( $admin_email ) && function_exists( 'is_email' ) && is_email( $admin_email ) ) {  
+            $resolved_admin = get_user_by( 'email', $admin_email );  
+            if ( $resolved_admin instanceof WP_User ) {  
+                $admin_user = $resolved_admin;  
+            } 
+		}
+			
+		return apply_filters( 'pmpro_approvals_admin_denied_email_data', $email_template_variables, $member, $admin_user );
 	}
 
 	/**
@@ -180,7 +190,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Denied extends PMPro_Email_Templ
 
 		$member = $random_user ? $random_user[0] : $current_user;
 
-		return array( $member, $current_user, $pmpro_email_test_level );
+		return array( $member, $pmpro_email_test_level );
 	}
 }
 /**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-denied.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-denied.php
@@ -31,7 +31,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Denied extends PMPro_Email_Templ
 	 * @param WP_User $member The user applying for membership.
 	 * @param int $level_id The level id.
 	 */
-	public function __construct( WP_User $member, WP_User $admin, StdClass $level ) {
+	public function __construct( WP_User $member, $admin = NULL, StdClass $level ) {
 		$this->member = $member;
 		$this->admin = $admin;
 		$this->level = $level;

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-notification-approval.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-notification-approval.php
@@ -17,13 +17,6 @@ class PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval extends PM
 	protected $level;
 
 	/**
-	 * The admin user will receive the email.
-	 * 
-	 * @var WP_User
-	 */
-	protected $admin;
-
-	/**
 	 * Constructor.
 	 *
 	 * @since 1.6.2
@@ -31,10 +24,9 @@ class PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval extends PM
 	 * @param WP_User $member The user applying for membership.
 	 * @param int $level_id The level id.
 	 */
-	public function __construct( WP_User $member, $admin = NULL, stdClass $level ) {
+	public function __construct( WP_User $member, stdClass $level ) {
 		$this->member = $member;
 		$this->level = $level;
-		$this->admin = $admin;
 	}
 
 	/**
@@ -124,7 +116,6 @@ class PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval extends PM
 	public function get_email_template_variables() {
 		$level = $this->level;
 		$member = $this->member;
-		$admin = $this->admin;
 		$view_profile = admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $member->ID . '&l=' . $level->id );
 		$email_template_variables = array(
 			'member_name' => $member->display_name,
@@ -136,10 +127,10 @@ class PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval extends PM
 			'deny_link' => $view_profile . '&deny=' . $member->ID,
 			'subject' => $this->get_default_subject(),
 			'name' => $this->get_recipient_name(),
-			'user_login' => isset( $admin->user_login ) ? $admin->user_login : "",
+			'user_login' => $this->get_recipient_name()
 		);
 
-		return apply_filters( 'pmpro_approvals_admin_pending_email_data', $email_template_variables, $member, $admin );
+		return apply_filters( 'pmpro_approvals_admin_pending_email_data', $email_template_variables, $member, null );
 	}
 
 	/**
@@ -150,7 +141,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval extends PM
 	 * @return string The email address to send the email to.
 	 */
 	public function get_recipient_email() {
-		return ! empty( $this->admin->user_email ) ? $this->admin->user_email : get_bloginfo( 'admin_email' );
+		return get_bloginfo( 'admin_email' );
 	}
 
 	/**
@@ -161,7 +152,8 @@ class PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval extends PM
 	 * @return string The name of the email recipient.
 	 */
 	public function get_recipient_name() {
-		return empty( $this->admin->display_name ) ? esc_html__( 'Admin', 'pmpro-approvals' ) : $this->admin->display_name;
+		$user = get_user_by( 'email', $this->get_recipient_email() );
+		return empty( $user->display_name ) ? esc_html__( 'Admin', 'pmpro-approvals' ) : $user->display_name;
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-notification-approval.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-notification-approval.php
@@ -130,7 +130,18 @@ class PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval extends PM
 			'user_login' => $this->get_recipient_name()
 		);
 
-		return apply_filters( 'pmpro_approvals_admin_pending_email_data', $email_template_variables, $member, null );
+		// Preserve backward compatibility by passing an admin context object  
+        // (WP_User when available, or false otherwise) as the third argument.  
+        $admin_user  = false;  
+        $admin_email = $this->get_recipient_email();  
+        if ( ! empty( $admin_email ) && function_exists( 'is_email' ) && is_email( $admin_email ) ) {  
+            $resolved_admin = get_user_by( 'email', $admin_email );  
+            if ( $resolved_admin instanceof WP_User ) {  
+                $admin_user = $resolved_admin;  
+            }
+		}
+
+		return apply_filters( 'pmpro_approvals_admin_pending_email_data', $email_template_variables, $member, $admin_user );
 	}
 
 	/**
@@ -182,7 +193,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval extends PM
 
 		$member = $random_user ? $random_user[0] : $current_user;
 
-		return array( $member, $current_user, $pmpro_email_test_level );
+		return array( $member, $pmpro_email_test_level );
 	}
 }
 /**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-notification-approval.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-notification-approval.php
@@ -31,7 +31,7 @@ class PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval extends PM
 	 * @param WP_User $member The user applying for membership.
 	 * @param int $level_id The level id.
 	 */
-	public function __construct( WP_User $member, WP_User $admin, stdClass $level ) {
+	public function __construct( WP_User $member, $admin = NULL, stdClass $level ) {
 		$this->member = $member;
 		$this->level = $level;
 		$this->admin = $admin;


### PR DESCRIPTION
* BUG FIX: Fixes an issue where admin emails are not being sent when the recipient email is not a valid WP user.

Resolves: https://github.com/strangerstudios/pmpro-approvals/issues/217