### PR TITLE
Update email templates to use liquid syntax for PMPro 3.7+

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-approved.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-approved.php
@@ -85,11 +85,11 @@ class PMPro_Email_Template_PMProApprovals_Admin_Approved extends PMPro_Email_Tem
 			// Running a version of PMPro before liquid email rendering was available.
 			return wp_kses_post( __( '<p>The user <a href="!!view_profile!!">!!member_name!!</a> has been approved.</p>
 
-<p>Log in to your membership account here: !!login_link!!</p>' ), 'pmpro-approvals' );
+<p>Log in to your membership account here: !!login_link!!</p>', 'pmpro-approvals' ) );
 		}
 		return wp_kses_post( __( '<p>The user <a href="{{ view_profile }}">{{ member_name }}</a> has been approved.</p>
 
-<p>Log in to your membership account here: {{ login_link }}</p>' ), 'pmpro-approvals' );
+<p>Log in to your membership account here: {{ login_link }}</p>', 'pmpro-approvals' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-approved.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-approved.php
@@ -81,9 +81,15 @@ class PMPro_Email_Template_PMProApprovals_Admin_Approved extends PMPro_Email_Tem
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( __( '<p>The user <a href="!!view_profile!!">!!member_name!!</a> has been approved.</p>
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return wp_kses_post( __( '<p>The user <a href="!!view_profile!!">!!member_name!!</a> has been approved.</p>
 
 <p>Log in to your membership account here: !!login_link!!</p>' ), 'pmpro-approvals' );
+		}
+		return wp_kses_post( __( '<p>The user <a href="{{ view_profile }}">{{ member_name }}</a> has been approved.</p>
+
+<p>Log in to your membership account here: {{ login_link }}</p>' ), 'pmpro-approvals' );
 	}
 
 	/**
@@ -94,12 +100,22 @@ class PMPro_Email_Template_PMProApprovals_Admin_Approved extends PMPro_Email_Tem
 	 * @return array The email template variables for the email (key => value pairs).
 	 */
 	public static function get_email_template_variables_with_description() {
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return array(
+				'!!member_name!!' => esc_html__( 'The name of the member.', 'pmpro-approvals' ),
+				'!!member_email!!' => esc_html__( 'The email address of the member.', 'pmpro-approvals' ),
+				'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'pmpro-approvals' ),
+				'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'pmpro-approvals' ),
+				'!!view_profile!!' => esc_html__( 'The URL of the profile page for the member.', 'pmpro-approvals' ),
+			);
+		}
 		return array(
-			'!!member_name!!' => esc_html__( 'The name of the member.', 'pmpro-approvals' ),
-			'!!member_email!!' => esc_html__( 'The email address of the member.', 'pmpro-approvals' ),
-			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'pmpro-approvals' ),
-			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'pmpro-approvals' ),
-			'!!view_profile!!' => esc_html__( 'The URL of the profile page for the member.', 'pmpro-approvals' ),
+			'{{ member_name }}' => esc_html__( 'The name of the member.', 'pmpro-approvals' ),
+			'{{ member_email }}' => esc_html__( 'The email address of the member.', 'pmpro-approvals' ),
+			'{{ membership_id }}' => esc_html__( 'The ID of the membership level.', 'pmpro-approvals' ),
+			'{{ membership_level_name }}' => esc_html__( 'The name of the membership level.', 'pmpro-approvals' ),
+			'{{ view_profile }}' => esc_html__( 'The URL of the profile page for the member.', 'pmpro-approvals' ),
 		);
 	}
 

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-denied.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-denied.php
@@ -81,9 +81,15 @@ class PMPro_Email_Template_PMProApprovals_Admin_Denied extends PMPro_Email_Templ
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( __( '<p>The user <a href="!!view_profile!!">!!member_name!!</a> has been denied.</p>
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return wp_kses_post( __( '<p>The user <a href="!!view_profile!!">!!member_name!!</a> has been denied.</p>
 
 <p>Log in to your membership account here: !!login_link!!</p>' ), 'pmpro-approvals' );
+		}
+		return wp_kses_post( __( '<p>The user <a href="{{ view_profile }}">{{ member_name }}</a> has been denied.</p>
+
+<p>Log in to your membership account here: {{ login_link }}</p>' ), 'pmpro-approvals' );
 	}
 
 
@@ -95,12 +101,22 @@ class PMPro_Email_Template_PMProApprovals_Admin_Denied extends PMPro_Email_Templ
 	 * @return array The email template variables for the email (key => value pairs).
 	 */
 	public static function get_email_template_variables_with_description() {
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return array(
+				'!!member_name!!' => esc_html__( 'The name of the member.', 'pmpro-approvals' ),
+				'!!member_email!!' => esc_html__( 'The email address of the member.', 'pmpro-approvals' ),
+				'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'pmpro-approvals' ),
+				'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'pmpro-approvals' ),
+				'!!view_profile!!' => esc_html__( 'The URL of the profile page for the member.', 'pmpro-approvals' ),
+			);
+		}
 		return array(
-			'!!member_name!!' => esc_html__( 'The name of the member.', 'pmpro-approvals' ),
-			'!!member_email!!' => esc_html__( 'The email address of the member.', 'pmpro-approvals' ),
-			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'pmpro-approvals' ),
-			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'pmpro-approvals' ),
-			'!!view_profile!!' => esc_html__( 'The URL of the profile page for the member.', 'pmpro-approvals' ),
+			'{{ member_name }}' => esc_html__( 'The name of the member.', 'pmpro-approvals' ),
+			'{{ member_email }}' => esc_html__( 'The email address of the member.', 'pmpro-approvals' ),
+			'{{ membership_id }}' => esc_html__( 'The ID of the membership level.', 'pmpro-approvals' ),
+			'{{ membership_level_name }}' => esc_html__( 'The name of the membership level.', 'pmpro-approvals' ),
+			'{{ view_profile }}' => esc_html__( 'The URL of the profile page for the member.', 'pmpro-approvals' ),
 		);
 	}
 

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-denied.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-denied.php
@@ -85,11 +85,11 @@ class PMPro_Email_Template_PMProApprovals_Admin_Denied extends PMPro_Email_Templ
 			// Running a version of PMPro before liquid email rendering was available.
 			return wp_kses_post( __( '<p>The user <a href="!!view_profile!!">!!member_name!!</a> has been denied.</p>
 
-<p>Log in to your membership account here: !!login_link!!</p>' ), 'pmpro-approvals' );
+<p>Log in to your membership account here: !!login_link!!</p>', 'pmpro-approvals' ) );
 		}
 		return wp_kses_post( __( '<p>The user <a href="{{ view_profile }}">{{ member_name }}</a> has been denied.</p>
 
-<p>Log in to your membership account here: {{ login_link }}</p>' ), 'pmpro-approvals' );
+<p>Log in to your membership account here: {{ login_link }}</p>', 'pmpro-approvals' ) );
 	}
 
 

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-notification-approval.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-admin-notification-approval.php
@@ -81,9 +81,15 @@ class PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval extends PM
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( __( '<p>The user !!member_name!! is pending approval.</p>
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return wp_kses_post( __( '<p>The user !!member_name!! is pending approval.</p>
 
 <p>View the user\'s profile here: !!view_profile!!</p>', 'pmpro-approvals' ) );
+		}
+		return wp_kses_post( __( '<p>The user {{ member_name }} is pending approval.</p>
+
+<p>View the user\'s profile here: {{ view_profile }}</p>', 'pmpro-approvals' ) );
 	}
 
 
@@ -95,14 +101,26 @@ class PMPro_Email_Template_PMProApprovals_Admin_Notification_Approval extends PM
 	 * @return array The email template variables for the email (key => value pairs).
 	 */
 	public static function get_email_template_variables_with_description() {
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return array(
+				'!!member_name!!' => esc_html__( 'The name of the member.', 'pmpro-approvals' ),
+				'!!member_email!!' => esc_html__( 'The email address of the member.', 'pmpro-approvals' ),
+				'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'pmpro-approvals' ),
+				'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'pmpro-approvals' ),
+				'!!view_profile!!' => esc_html__( 'The URL of the profile page for the member.', 'pmpro-approvals' ),
+				'!!approve_link!!' => esc_html__( 'The URL to approve the member.', 'pmpro-approvals' ),
+				'!!deny_link!!' => esc_html__( 'The URL to deny the member.', 'pmpro-approvals' ),
+			);
+		}
 		return array(
-			'!!member_name!!' => esc_html__( 'The name of the member.', 'pmpro-approvals' ),
-			'!!member_email!!' => esc_html__( 'The email address of the member.', 'pmpro-approvals' ),
-			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'pmpro-approvals' ),
-			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'pmpro-approvals' ),
-			'!!view_profile!!' => esc_html__( 'The URL of the profile page for the member.', 'pmpro-approvals' ),
-			'!!approve_link!!' => esc_html__( 'The URL to approve the member.', 'pmpro-approvals' ),
-			'!!deny_link!!' => esc_html__( 'The URL to deny the member.', 'pmpro-approvals' ),
+			'{{ member_name }}' => esc_html__( 'The name of the member.', 'pmpro-approvals' ),
+			'{{ member_email }}' => esc_html__( 'The email address of the member.', 'pmpro-approvals' ),
+			'{{ membership_id }}' => esc_html__( 'The ID of the membership level.', 'pmpro-approvals' ),
+			'{{ membership_level_name }}' => esc_html__( 'The name of the membership level.', 'pmpro-approvals' ),
+			'{{ view_profile }}' => esc_html__( 'The URL of the profile page for the member.', 'pmpro-approvals' ),
+			'{{ approve_link }}' => esc_html__( 'The URL to approve the member.', 'pmpro-approvals' ),
+			'{{ deny_link }}' => esc_html__( 'The URL to deny the member.', 'pmpro-approvals' ),
 		);
 	}
 

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-application-approved.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-application-approved.php
@@ -84,10 +84,10 @@ class PMPro_Email_Template_PMProApprovals_Application_Approved extends PMPro_Ema
 		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
 			// Running a version of PMPro before liquid email rendering was available.
 			return wp_kses_post( __( '<p>Your membership account at !!sitename!! has been approved.</p>
-<p>Log in to your membership account here: !!login_link!!</p>' ) );
+<p>Log in to your membership account here: !!login_link!!</p>', 'pmpro-approvals' ) );
 		}
 		return wp_kses_post( __( '<p>Your membership account at {{ sitename }} has been approved.</p>
-<p>Log in to your membership account here: {{ login_link }}</p>' ) );
+<p>Log in to your membership account here: {{ login_link }}</p>', 'pmpro-approvals' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-application-approved.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-application-approved.php
@@ -81,8 +81,13 @@ class PMPro_Email_Template_PMProApprovals_Application_Approved extends PMPro_Ema
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( __( '<p>Your membership account at !!sitename!! has been approved.</p>
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return wp_kses_post( __( '<p>Your membership account at !!sitename!! has been approved.</p>
 <p>Log in to your membership account here: !!login_link!!</p>' ) );
+		}
+		return wp_kses_post( __( '<p>Your membership account at {{ sitename }} has been approved.</p>
+<p>Log in to your membership account here: {{ login_link }}</p>' ) );
 	}
 
 	/**
@@ -93,10 +98,18 @@ class PMPro_Email_Template_PMProApprovals_Application_Approved extends PMPro_Ema
 	 * @return array The email template variables for the email (key => value pairs).
 	 */
 	public static function get_email_template_variables_with_description() {
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return array(
+				'!!member_email!!' => esc_html__( 'The email address of the member.', 'pmpro-approvals' ),
+				'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'pmpro-approvals' ),
+				'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'pmpro-approvals' ),
+			);
+		}
 		return array(
-			'!!member_email!!' => esc_html__( 'The email address of the member.', 'pmpro-approvals' ),
-			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'pmpro-approvals' ),
-			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'pmpro-approvals' ),
+			'{{ member_email }}' => esc_html__( 'The email address of the member.', 'pmpro-approvals' ),
+			'{{ membership_id }}' => esc_html__( 'The ID of the membership level.', 'pmpro-approvals' ),
+			'{{ membership_level_name }}' => esc_html__( 'The name of the membership level.', 'pmpro-approvals' ),
 		);
 	}
 

--- a/classes/email-templates/class-pmpro-email-template-pmpro-approvals-application-denied.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-approvals-application-denied.php
@@ -92,10 +92,18 @@ class PMPro_Email_Template_PMProApprovals_Application_Denied extends PMPro_Email
 	 * @return array The email template variables for the email (key => value pairs).
 	 */
 	public static function get_email_template_variables_with_description() {
+		if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+			// Running a version of PMPro before liquid email rendering was available.
+			return array(
+				'!!member_email!!' => esc_html__( 'The email address of the member.', 'pmpro-approvals' ),
+				'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'pmpro-approvals' ),
+				'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'pmpro-approvals' ),
+			);
+		}
 		return array(
-			'!!member_email!!' => esc_html__( 'The email address of the member.', 'pmpro-approvals' ),
-			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'pmpro-approvals' ),
-			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'pmpro-approvals' ),
+			'{{ member_email }}' => esc_html__( 'The email address of the member.', 'pmpro-approvals' ),
+			'{{ membership_id }}' => esc_html__( 'The ID of the membership level.', 'pmpro-approvals' ),
+			'{{ membership_level_name }}' => esc_html__( 'The name of the membership level.', 'pmpro-approvals' ),
 		);
 	}
 


### PR DESCRIPTION
## Summary
- Adds `PMPro_Liquid_Renderer` class existence check to `get_default_body()` and `get_email_template_variables_with_description()` methods across all 5 email template classes.
- When the class exists (PMPro 3.7+), uses `{{ variable }}` liquid syntax; otherwise falls back to `!!variable!!` syntax for backward compatibility.
- `get_default_subject()` methods were not changed as they do not use template variable syntax.
- `get_email_template_variables()` methods were not changed as they do not use `!!` syntax.

## Test plan
- [ ] Verify emails render correctly with PMPro 3.7+ (liquid syntax `{{ }}` should be used)
- [ ] Verify emails render correctly with PMPro < 3.7 (legacy `!!` syntax should be used)
- [ ] Test each email type: admin approved, admin notification approval, application approved, admin denied, application denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)