### PR TITLE
Overhaul Approvals admin UX: application view, Member Edit panel, and list filters

### DIFF
--- a/adminpages/approvals.php
+++ b/adminpages/approvals.php
@@ -25,10 +25,10 @@ if ( isset( $_REQUEST['status'] ) ) {
 	$status = '';
 }
 
-	//make sure sortby is whitelisted
-	$statuses = array( '', 'all', 'pending', 'approved', 'denied' );
+	//make sure status is whitelisted
+	$statuses = array( 'all', 'pending', 'approved', 'denied' );
 if ( empty( $status ) || ! in_array( $status, $statuses ) ) {
-	$status = 'pending';
+	$status = 'all';
 }
 
 	//Approve, deny or reset member back to pending
@@ -37,90 +37,22 @@ if ( ! empty( $_REQUEST['approve'] ) ) {
 	if ( ! PMPro_Approvals::isApproved( intval( $_REQUEST['approve'] ), $l ) ) {
 		PMPro_Approvals::approveMember( intval( $_REQUEST['approve'] ), $l );
 		$l = false;
-		$status = 'pending';
 	}
 } elseif ( ! empty( $_REQUEST['deny'] ) ) {
 	check_admin_referer( 'pmpro_approvals', 'pmpro_approvals_nonce' );
 	if ( ! PMPro_Approvals::isDenied( intval( $_REQUEST['deny'] ), $l ) ) {
 		PMPro_Approvals::denyMember( intval( $_REQUEST['deny'] ), $l );
 		$l = false;
-		$status = 'pending';
 	}
 } elseif ( ! empty( $_REQUEST['unapprove'] ) ) {
 	check_admin_referer( 'pmpro_approvals', 'pmpro_approvals_nonce' );
 	PMPro_Approvals::resetMember( intval( $_REQUEST['unapprove'] ), $l );
 	$l = false;
-	$status = 'pending';
 }
 
 	require_once PMPRO_DIR . '/adminpages/admin_header.php';
-?>
-<hr class="wp-header-end" />
-<h1><?php esc_html_e( 'Approvals', 'pmpro-approvals' ); ?></h1>
-<p>
-	<?php
-		$approval_settings_link = '<a title="' . esc_attr__( 'Paid Memberships Pro - Approvals Add On Documentation', 'pmpro-approvals' ) . '" target="_blank" rel="nofollow noopener" href="https://www.paidmembershipspro.com/add-ons/approval-process-membership/?utm_source=plugin&utm_medium=pmpro-approvals&utm_campaign=add-ons">' . esc_html__( 'Approvals Add On', 'pmpro-approvals' ) . '</a>';
-		// translators: %s: Link to Approvals Add On documentation.
-		$approval_settings_text = sprintf( esc_html__( 'Learn more about using the %s.', 'pmpro-approvals' ), $approval_settings_link );
-		echo wp_kses_post( $approval_settings_text );
-	?>
-</p>
-<ul class="subsubsub">
-<?php
-	$statuses_labels = array(
-		'all'      => __( 'All', 'pmpro-approvals' ),
-		'pending'  => __( 'Pending', 'pmpro-approvals' ),
-		'approved' => __( 'Approved', 'pmpro-approvals' ),
-		'denied'   => __( 'Denied', 'pmpro-approvals' ),
-	);
 
-	$items = array();
-	foreach ( $statuses_labels as $key => $label ) {
-		$url     = admin_url( 'admin.php?page=pmpro-approvals&s=' . urlencode( $s ) . "&l=$l&status=$key" );
-		$current = ( $status === $key || ( $key === 'pending' && empty( $status ) ) ) ? 'class="current"' : '';
-		$items[] = '<li class="' . esc_attr( $key ) . '"><a href="' . esc_url( $url ) . '" ' . $current . '>' . esc_html( $label ) . '</a></li>';
-	}
-
-	echo implode( ' | ', $items );
-?>
-</ul>
-<form id="posts-filter" method="get" action="">
-	<p class="search-box">
-		<label class="hidden" for="post-search-input"><?php _e( 'Search Approvals', 'pmpro-approvals' ); ?>:</label>
-		<input type="hidden" name="page" value="pmpro-approvals" />
-		<input type="hidden" name="status" value="<?php echo esc_attr( $status ); ?>" />		
-		<input id="post-search-input" type="text" value="<?php echo esc_attr( $s ); ?>" name="s"/>
-		<input class="button" type="submit" value="<?php _e( 'Search Approvals', 'pmpro-approvals' ); ?>"/>
-	</p>
-	<div class="tablenav top">	
-		<?php esc_html_e( 'Show', 'pmpro-approvals' ); ?> 
-		<select name="l" onchange="jQuery('#posts-filter').submit();">
-			<option value="" 
-				<?php if ( ! $l ) { ?>
-					selected="selected"
-				<?php } ?>>
-				<?php esc_html_e( 'All Levels', 'pmpro-approvals' ); ?>
-			</option>
-			<?php
-				$approval_level_ids = PMPro_Approvals::getApprovalLevels();
-				if ( ! empty( $approval_level_ids ) ) {
-					$levels = $wpdb->get_results( "SELECT id, name FROM $wpdb->pmpro_membership_levels WHERE id IN(" . implode( ',', $approval_level_ids ) . ') ORDER BY name' );
-					foreach ( $levels as $level ) {
-						?>
-						<option value="<?php echo $level->id; ?>" 
-							<?php if ( $l == $level->id ) { ?>
-								selected="selected"
-							<?php } ?>>
-							<?php echo $level->name; ?>
-						</option>
-					<?php
-					}
-				}
-			?>
-		</select>
-	</div>
-	<?php
-		//some vars for the search
+	//some vars for the search
 	if ( isset( $_REQUEST['pn'] ) ) {
 		$pn = intval( $_REQUEST['pn'] );
 	} else {
@@ -133,8 +65,8 @@ if ( ! empty( $_REQUEST['approve'] ) ) {
 		$sortby = 'user_registered';
 	}
 
-		//make sure sortby is whitelisted
-		$sortbys = array( 'pmpro_approval', 'user_registered' );
+	//make sure sortby is whitelisted
+	$sortbys = array( 'pmpro_approval', 'user_registered' );
 	if ( ! in_array( $sortby, $sortbys ) ) {
 		$sortby = 'user_registered';
 	}
@@ -151,136 +83,217 @@ if ( ! empty( $_REQUEST['approve'] ) ) {
 		$limit = 15;
 	}
 
-		$approval_users  = PMPro_Approvals::getApprovals( $l, $s, $status, $sortby, $sortorder, $pn, $limit );
-		$totalrows = PMPro_Approvals::getApprovalCount( $status, $l, $s );
-
-	if ( $approval_users ) {
-		?>
-		<p class="clear">
-			<?php
-			if ( $status === 'pending' ) {
-				printf(
-					esc_html( _n( '%d application awaiting review', '%d applications awaiting review', (int) $totalrows, 'pmpro-approvals' ) ),
-					esc_html( (int) $totalrows )
-				);
-			}
-			?>
+	$approval_users  = PMPro_Approvals::getApprovals( $l, $s, $status, $sortby, $sortorder, $pn, $limit );
+	$totalrows = PMPro_Approvals::getApprovalCount( $status, $l, $s );
+?>
+<hr class="wp-header-end" />
+<form id="posts-filter" method="get" action="">
+	<h1 class="wp-heading-inline" style="margin-top: 0;"><?php esc_html_e( 'Approvals', 'pmpro-approvals' ); ?></h1>
+	<input type="hidden" name="page" value="pmpro-approvals" />
+	<?php if ( $approval_users ) { ?>
+		<p class="search-box">
+			<label class="hidden" for="post-search-input"><?php _e( 'Search Approvals', 'pmpro-approvals' ); ?>:</label>
+			<input id="post-search-input" type="text" value="<?php echo esc_attr( $s ); ?>" name="s"/>
+			<input class="button" type="submit" value="<?php _e( 'Search Approvals', 'pmpro-approvals' ); ?>"/>
 		</p>
+	<?php } ?>
+	<p>
+		<?php
+			$approval_settings_link = '<a title="' . esc_attr__( 'Paid Memberships Pro - Approvals Add On Documentation', 'pmpro-approvals' ) . '" target="_blank" rel="nofollow noopener" href="https://www.paidmembershipspro.com/add-ons/approval-process-membership/?utm_source=plugin&utm_medium=pmpro-approvals&utm_campaign=add-ons">' . esc_html__( 'Approvals Add On', 'pmpro-approvals' ) . '</a>';
+			// translators: %s: Link to Approvals Add On documentation.
+			$approval_settings_text = sprintf( esc_html__( 'Learn more about using the %s.', 'pmpro-approvals' ), $approval_settings_link );
+			echo wp_kses_post( $approval_settings_text );
+		?>
+	</p>
+	<?php if ( $approval_users ) { ?>
+		<div class="tablenav top">
+			<div class="alignleft actions">
+				<label class="screen-reader-text" for="filter-by-level"><?php esc_html_e( 'Filter by level', 'pmpro-approvals' ); ?></label>
+				<select name="l" id="filter-by-level">
+					<option value="0"><?php esc_html_e( 'All Levels', 'pmpro-approvals' ); ?></option>
+					<?php
+						$approval_level_ids = PMPro_Approvals::getApprovalLevels();
+						if ( ! empty( $approval_level_ids ) ) {
+							$levels = $wpdb->get_results( "SELECT id, name FROM $wpdb->pmpro_membership_levels WHERE id IN(" . implode( ',', $approval_level_ids ) . ') ORDER BY name' );
+							foreach ( $levels as $level ) {
+								?>
+								<option value="<?php echo esc_attr( $level->id ); ?>" <?php selected( $l, $level->id ); ?>><?php echo esc_html( $level->name ); ?></option>
+								<?php
+							}
+						}
+					?>
+				</select>
+				<label class="screen-reader-text" for="filter-by-status"><?php esc_html_e( 'Filter by status', 'pmpro-approvals' ); ?></label>
+				<select name="status" id="filter-by-status">
+					<option value="all" <?php selected( $status, 'all' ); ?>><?php esc_html_e( 'All Statuses', 'pmpro-approvals' ); ?></option>
+					<option value="pending" <?php selected( $status, 'pending' ); ?>><?php esc_html_e( 'Pending', 'pmpro-approvals' ); ?></option>
+					<option value="approved" <?php selected( $status, 'approved' ); ?>><?php esc_html_e( 'Approved', 'pmpro-approvals' ); ?></option>
+					<option value="denied" <?php selected( $status, 'denied' ); ?>><?php esc_html_e( 'Denied', 'pmpro-approvals' ); ?></option>
+				</select>
+				<?php submit_button( __( 'Filter', 'pmpro-approvals' ), '', 'filter_action', false ); ?>
+			</div>
+			<div class="tablenav-pages">
+				<span class="displaying-num"><?php echo esc_html( sprintf( _n( '1 item', '%s items', $totalrows, 'pmpro-approvals' ), number_format_i18n( $totalrows ) ) ); ?></span>
+			</div>
+		</div>
+	
+		<table class="widefat striped pmpro_responsive_table">
+			<thead>
+				<tr class="thead">
+					<th><?php esc_html_e( 'ID', 'pmpro-approvals' ); ?></th>
+					<th><?php esc_html_e( 'Applicant', 'pmpro-approvals' ); ?></th>
+					<th><?php esc_html_e( 'Email', 'pmpro-approvals' ); ?></th>
+					<?php do_action( 'pmpro_approvals_list_extra_cols_header', $approval_users ); ?>
+					<th><?php esc_html_e( 'Membership', 'pmpro-approvals' ); ?></th>
+					<th><?php esc_html_e( 'Approval Status', 'pmpro-approvals' ); ?></th>
+					<th><a href="<?php echo admin_url( 'admin.php?page=pmpro-approvals&s=' . esc_attr( $s ) . '&limit=' . $limit . '&pn=' . $pn . '&sortby=user_registered' ); ?>
+											<?php
+											if ( $sortby == 'user_registered' && $sortorder == 'DESC' ) {
+							?>
+							&sortorder=ASC<?php } ?>"><?php _e( 'Joined', 'pmpro-approvals' ); ?></a></th>				
+				</tr>
+			</thead>
+			<tbody>	
+			<?php
+				foreach ( $approval_users as $approval_user ) {
+					//get meta
+					$user_data = get_userdata( $approval_user->ID );
+					?>
+					<tr>
+						<td data-colname="<?php esc_attr_e( 'ID', 'pmpro-approvals' ); ?>"><?php echo $user_data->ID; ?></td>
+						<td class="username column-username has-row-actions" data-colname="<?php esc_attr_e( 'Applicant', 'pmpro-approvals' ); ?>">
+							<?php echo get_avatar( $user_data->ID, 32 ); ?>								
+							<?php
+								$pmpro_approval_view_url = add_query_arg(
+									array(
+										'page'    => 'pmpro-approvals',
+										'user_id' => (int) $user_data->ID,
+										'l'       => (int) $approval_user->membership_id,
+									),
+									admin_url( 'admin.php' )
+								);
+							?>
+							<strong><a href="<?php echo esc_url( $pmpro_approval_view_url ); ?>"><?php echo esc_html( $user_data->display_name ); ?></a></strong>
+							<?php
+								// Set up the hover actions for this user.
+								$pmpro_approvals_nonce      = wp_create_nonce( 'pmpro_approvals' );
+								$pmpro_approval_action_base = add_query_arg(
+									array(
+										'page'                  => 'pmpro-approvals',
+										's'                     => $s,
+										'l'                     => (int) $approval_user->membership_id,
+										'limit'                 => (int) $limit,
+										'status'                => $status,
+										'sortby'                => $sortby,
+										'sortorder'             => $sortorder,
+										'pn'                    => (int) $pn,
+										'pmpro_approvals_nonce' => $pmpro_approvals_nonce,
+									),
+									admin_url( 'admin.php' )
+								);
+
+								$actions = array();
+
+								$actions['pmpro_approvals_view'] = '<a href="' . esc_url( $pmpro_approval_view_url ) . '">' . esc_html__( 'View Application', 'pmpro-approvals' ) . '</a>';
+
+								if ( PMPro_Approvals::isApproved( $user_data->ID, $approval_user->membership_id ) || PMPro_Approvals::isDenied( $user_data->ID, $approval_user->membership_id ) ) {
+									$pmpro_approval_reset_url          = add_query_arg( 'unapprove', (int) $user_data->ID, $pmpro_approval_action_base );
+									$actions['pmpro_approvals_reset'] = '<a href="javascript:askfirst(\'' . esc_js( sprintf( __( 'Are you sure you want to reset approval for %s?', 'pmpro-approvals' ), $user_data->user_login ) ) . '\', \'' . esc_js( $pmpro_approval_reset_url ) . '\');">' . esc_html__( 'Reset Approval', 'pmpro-approvals' ) . '</a>';
+								} else {
+									$actions['pmpro_approvals_approve'] = '<a href="' . esc_url( add_query_arg( 'approve', (int) $user_data->ID, $pmpro_approval_action_base ) ) . '">' . esc_html__( 'Approve', 'pmpro-approvals' ) . '</a>';
+									$actions['pmpro_approvals_deny']    = '<a href="' . esc_url( add_query_arg( 'deny', (int) $user_data->ID, $pmpro_approval_action_base ) ) . '">' . esc_html__( 'Deny', 'pmpro-approvals' ) . '</a>';
+								}
+
+								if ( function_exists( 'pmpro_member_edit_get_panels' ) && function_exists( 'pmpro_get_edit_member_capability' ) && current_user_can( pmpro_get_edit_member_capability() ) ) {
+									$actions['editmember'] = '<a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-member', 'user_id' => (int) $user_data->ID ), admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'Edit Member', 'pmpro-approvals' ) . '</a>';
+								}
+								if ( current_user_can( 'edit_users' ) ) {
+									$actions['edituser'] = '<a href="' . esc_url( add_query_arg( array( 'user_id' => (int) $user_data->ID ), admin_url( 'user-edit.php' ) ) ) . '">' . esc_html__( 'Edit User', 'pmpro-approvals' ) . '</a>';
+								}
+
+								/**
+								 * Filter the extra actions for this user in the approvals list table.
+								 *
+								 * @param array  $actions  The list of actions.
+								 * @param object $template  The user data for this row.
+								 * @param object $approval_user  The approval user data for this row.
+								 */
+								$actions = apply_filters( 'pmpro_approvals_user_row_actions', $actions, $user_data, $approval_user );
+
+								$actions_html = [];
+							?>
+							<div class="row-actions">
+								<?php
+									foreach ( $actions as $action => $link ) {
+										$actions_html[] = sprintf(
+											'<span class="%1$s">%2$s</span>',
+											esc_attr( $action ),
+											$link
+										);
+									}
+									if ( ! empty( $actions_html ) ) {
+										echo implode( ' | ', $actions_html ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+									}
+								?>
+							</div>
+						</td>
+						<td data-colname="<?php esc_attr_e( 'Email', 'pmpro-approvals' ); ?>">
+							<?php echo esc_html( $user_data->user_email ); ?>
+						</td>
+						<?php do_action( 'pmpro_approvals_list_extra_cols_body', $user_data ); ?>						
+						<td data-colname="<?php esc_attr_e( 'Membership', 'pmpro-approvals' ); ?>">
+							<?php echo $approval_user->membership; ?>
+						</td>						
+						<td data-colname="<?php esc_attr_e( 'Approval Status', 'pmpro-approvals' ); ?>">										
+							<?php
+								if ( PMPro_Approvals::isApproved( $user_data->ID, $approval_user->membership_id ) ) {
+									$pmpro_approval_badge_class = 'pmpro_tag-success';
+									$pmpro_approval_badge_label = __( 'Approved', 'pmpro-approvals' );
+								} elseif ( PMPro_Approvals::isDenied( $user_data->ID, $approval_user->membership_id ) ) {
+									$pmpro_approval_badge_class = 'pmpro_tag-error';
+									$pmpro_approval_badge_label = __( 'Denied', 'pmpro-approvals' );
+								} else {
+									$pmpro_approval_badge_class = 'pmpro_tag-alert';
+									$pmpro_approval_badge_label = __( 'Pending', 'pmpro-approvals' );
+								}
+								echo '<span class="pmpro_tag ' . esc_attr( $pmpro_approval_badge_class ) . '">' . esc_html( $pmpro_approval_badge_label ) . '</span>';
+							?>
+						</td>
+						<td data-colname="<?php esc_attr_e( 'Joined', 'pmpro-approvals' ); ?>">
+							<?php echo date_i18n( get_option( 'date_format' ), strtotime( $user_data->user_registered ) ); ?>
+						</td>
+					</tr>
+					<?php
+				}
+			?>
+			</tbody>
+		</table>
+		<?php
+	} else {
+		?>
+		<p><?php esc_html_e( 'No members found.', 'pmpro-approvals' ); ?></p>
 		<?php
 	}
 	?>
-	<table class="widefat">
-		<thead>
-			<tr class="thead">
-				<th><?php _e( 'ID', 'pmpro-approvals' ); ?></th>
-				<th><?php _e( 'Username', 'pmpro-approvals' ); ?></th>
-				<th><?php _e( 'Name', 'pmpro-approvals' ); ?></th>				
-				<th><?php _e( 'Email', 'pmpro-approvals' ); ?></th>
-				<?php do_action( 'pmpro_approvals_list_extra_cols_header', $approval_users ); ?>
-				<th><?php _e( 'Membership', 'pmpro-approvals' ); ?></th>					
-				<th><?php _e( 'Approval Status', 'pmpro-approvals' ); ?></th>
-				<th><a href="<?php echo admin_url( 'admin.php?page=pmpro-approvals&s=' . esc_attr( $s ) . '&limit=' . $limit . '&pn=' . $pn . '&sortby=user_registered' ); ?>
-										<?php
-										if ( $sortby == 'user_registered' && $sortorder == 'DESC' ) {
-						?>
-						&sortorder=ASC<?php } ?>"><?php _e( 'Joined', 'pmpro-approvals' ); ?></a></th>				
-			</tr>
-		</thead>
-		<tbody id="users" class="list:user user-list">	
+	<div class="tablenav bottom">
+		<div class="tablenav-pages">
 			<?php
-				$count = 0;
-			foreach ( $approval_users as $approval_user ) {
-				//get meta
-				$user_data = get_userdata( $approval_user->ID );
-				?>
-					<tr 
-					<?php
-					if ( $count++ % 2 == 0 ) {
-?>
-class="alternate"<?php } ?>>
-						<td><?php echo $user_data->ID; ?></td>
-						<td class="username column-username">
-							<?php echo get_avatar( $user_data->ID, 32 ); ?>								
-							<?php if ( current_user_can( 'edit_users' ) ) { ?>
-									<strong><a href="user-edit.php?user_id=<?php echo $user_data->ID; ?>"><?php echo $user_data->user_login; ?></a></strong>
-								<?php } else { ?>
-									<strong><a href="admin.php?page=pmpro-approvals&user_id=<?php echo $user_data->ID; ?>"><?php echo $user_data->user_login; ?></a></strong>
-								<?php } ?>
-							<br />
-							<?php
-								// Set up the hover actions for this user
-								$actions      = apply_filters( 'pmpro_approvals_user_row_actions', array(), $user_data, $approval_user );
-								$action_count = count( $actions );
-								$i            = 0;
-							if ( $action_count ) {
-								$out = '<div class="row-actions">';
-								foreach ( $actions as $action => $link ) {
-									++$i;
-									( $i == $action_count ) ? $sep = '' : $sep = ' | ';
-									$out                          .= "<span class='$action'>$link$sep</span>";
-								}
-								$out .= '</div>';
-								echo $out;
-							}
-								?>
-							</td>
-							<td><?php echo trim( $user_data->first_name . ' ' . $user_data->last_name ); ?></td>							
-							<td><a href="mailto:<?php echo $user_data->user_email; ?>"><?php echo $user_data->user_email; ?></a></td>
-							<?php do_action( 'pmpro_approvals_list_extra_cols_body', $user_data ); ?>						
-							<td>
-								<?php
-								echo $approval_user->membership;
-								?>
-							</td>						
-							<td>										
-								<?php
-								$pmpro_approvals_nonce = wp_create_nonce( 'pmpro_approvals' );
-
-								if ( PMPro_Approvals::isApproved( $user_data->ID, $approval_user->membership_id) || PMPro_Approvals::isDenied( $user_data->ID, $approval_user->membership_id ) ) {
-
-									if ( ! PMPro_Approvals::getEmailConfirmation( $user_data->ID ) ) {
-										_e( 'Email Confirmation Required.', 'pmpro-approvals' );
-									} else {
-
-										echo PMPro_Approvals::getUserApprovalStatus( $user_data->ID, $approval_user->membership_id, false );
-
-										//link to unapprove
-										?>
-										[<a href="javascript:askfirst('Are you sure you want to reset approval for <?php echo $user_data->user_login; ?>?', '?page=pmpro-approvals&s=<?php echo esc_attr( $s ); ?>&l=<?php echo $approval_user->membership_id; ?>&limit=<?php echo intval( $limit ); ?>&status=<?php echo $status; ?>&sortby=<?php echo $sortby; ?>&sortorder=<?php echo $sortorder; ?>&pn=<?php echo intval( $pn ); ?>&unapprove=<?php echo $user_data->ID; ?>&pmpro_approvals_nonce=<?php echo urlencode( $pmpro_approvals_nonce ); ?>');">X</a>]
-										<?php
-									}
-								} else {
-									?>
-																			
-									<a href="?page=pmpro-approvals&s=<?php echo esc_attr( $s ); ?>&l=<?php echo $approval_user->membership_id; ?>&limit=<?php echo intval( $limit ); ?>&status=<?php echo $status; ?>&sortby=<?php echo $sortby; ?>&sortorder=<?php echo $sortorder; ?>&pn=<?php echo intval( $pn ); ?>&approve=<?php echo $user_data->ID; ?>&pmpro_approvals_nonce=<?php echo urlencode( $pmpro_approvals_nonce ); ?>"><?php _e('Approve', 'pmpro-approvals') ?></a> |
-									<a href="?page=pmpro-approvals&s=<?php echo esc_attr( $s ); ?>&l=<?php echo $approval_user->membership_id; ?>&limit=<?php echo intval( $limit ); ?>&status=<?php echo $status; ?>&sortby=<?php echo $sortby; ?>&sortorder=<?php echo $sortorder; ?>&pn=<?php echo intval( $pn ); ?>&deny=<?php echo $user_data->ID; ?>&pmpro_approvals_nonce=<?php echo urlencode( $pmpro_approvals_nonce ); ?>"><?php _e('Deny', 'pmpro-approvals') ?></a>
-									<?php
-								}
-								?>
-							</td>
-							<td><?php echo date_i18n( get_option( 'date_format' ), strtotime( $user_data->user_registered ) ); ?></td>							
-						</tr>
-					<?php
-			}
-
-			if ( ! $approval_users ) {
-				?>
-				<tr>
-				<td colspan="9"><p><?php _e( 'No pending members found.', 'pmpro-approvals' ); ?></p></td>
-				</tr>
-				<?php
-			}
+				// Pagination
+				echo wp_kses_post( 
+					pmpro_getPaginationString(
+						$pn,
+						$totalrows,
+						$limit,
+						1,
+						get_admin_url( null, '/admin.php?page=pmpro-approvals&s=' . urlencode( $s ) ),
+						"&l=$l&limit=$limit&status=$status&sortby=$sortby&sortorder=$sortorder&pn=", 
+						__( 'Approvals Pagination', 'pmpro-approvals' )
+					)
+				);
 			?>
-					
-		</tbody>
-	</table>
-	</form>
-	
-	<?php
-	echo pmpro_getPaginationString( $pn, $totalrows, $limit, 1, get_admin_url( null, '/admin.php?page=pmpro-approvals&s=' . urlencode( $s ) ), "&l=$l&limit=$limit&status=$status&sortby=$sortby&sortorder=$sortorder&pn=" );
-	?>
-	
+		</div>
+	</div>
+</form>
 <?php
 	require_once PMPRO_DIR . '/adminpages/admin_footer.php';
 ?>
-

--- a/adminpages/approvals.php
+++ b/adminpages/approvals.php
@@ -105,38 +105,40 @@ if ( ! empty( $_REQUEST['approve'] ) ) {
 			echo wp_kses_post( $approval_settings_text );
 		?>
 	</p>
-	<?php if ( $approval_users ) { ?>
-		<div class="tablenav top">
-			<div class="alignleft actions">
-				<label class="screen-reader-text" for="filter-by-level"><?php esc_html_e( 'Filter by level', 'pmpro-approvals' ); ?></label>
-				<select name="l" id="filter-by-level">
-					<option value="0"><?php esc_html_e( 'All Levels', 'pmpro-approvals' ); ?></option>
-					<?php
-						$approval_level_ids = PMPro_Approvals::getApprovalLevels();
-						if ( ! empty( $approval_level_ids ) ) {
-							$levels = $wpdb->get_results( "SELECT id, name FROM $wpdb->pmpro_membership_levels WHERE id IN(" . implode( ',', $approval_level_ids ) . ') ORDER BY name' );
-							foreach ( $levels as $level ) {
-								?>
-								<option value="<?php echo esc_attr( $level->id ); ?>" <?php selected( $l, $level->id ); ?>><?php echo esc_html( $level->name ); ?></option>
-								<?php
-							}
+	<div class="tablenav top">
+		<div class="alignleft actions">
+			<label class="screen-reader-text" for="filter-by-level"><?php esc_html_e( 'Filter by level', 'pmpro-approvals' ); ?></label>
+			<select name="l" id="filter-by-level">
+				<option value="0"><?php esc_html_e( 'All Levels', 'pmpro-approvals' ); ?></option>
+				<?php
+					$approval_level_ids = PMPro_Approvals::getApprovalLevels();
+					if ( ! empty( $approval_level_ids ) ) {
+						$levels = $wpdb->get_results( "SELECT id, name FROM $wpdb->pmpro_membership_levels WHERE id IN(" . implode( ',', $approval_level_ids ) . ') ORDER BY name' );
+						foreach ( $levels as $level ) {
+							?>
+							<option value="<?php echo esc_attr( $level->id ); ?>" <?php selected( $l, $level->id ); ?>><?php echo esc_html( $level->name ); ?></option>
+							<?php
 						}
-					?>
-				</select>
-				<label class="screen-reader-text" for="filter-by-status"><?php esc_html_e( 'Filter by status', 'pmpro-approvals' ); ?></label>
-				<select name="status" id="filter-by-status">
-					<option value="all" <?php selected( $status, 'all' ); ?>><?php esc_html_e( 'All Statuses', 'pmpro-approvals' ); ?></option>
-					<option value="pending" <?php selected( $status, 'pending' ); ?>><?php esc_html_e( 'Pending', 'pmpro-approvals' ); ?></option>
-					<option value="approved" <?php selected( $status, 'approved' ); ?>><?php esc_html_e( 'Approved', 'pmpro-approvals' ); ?></option>
-					<option value="denied" <?php selected( $status, 'denied' ); ?>><?php esc_html_e( 'Denied', 'pmpro-approvals' ); ?></option>
-				</select>
-				<?php submit_button( __( 'Filter', 'pmpro-approvals' ), '', 'filter_action', false ); ?>
-			</div>
-			<div class="tablenav-pages">
-				<span class="displaying-num"><?php echo esc_html( sprintf( _n( '1 item', '%s items', $totalrows, 'pmpro-approvals' ), number_format_i18n( $totalrows ) ) ); ?></span>
-			</div>
+					}
+				?>
+			</select>
+			<label class="screen-reader-text" for="filter-by-status"><?php esc_html_e( 'Filter by status', 'pmpro-approvals' ); ?></label>
+			<select name="status" id="filter-by-status">
+				<option value="all" <?php selected( $status, 'all' ); ?>><?php esc_html_e( 'All Statuses', 'pmpro-approvals' ); ?></option>
+				<option value="pending" <?php selected( $status, 'pending' ); ?>><?php esc_html_e( 'Pending', 'pmpro-approvals' ); ?></option>
+				<option value="approved" <?php selected( $status, 'approved' ); ?>><?php esc_html_e( 'Approved', 'pmpro-approvals' ); ?></option>
+				<option value="denied" <?php selected( $status, 'denied' ); ?>><?php esc_html_e( 'Denied', 'pmpro-approvals' ); ?></option>
+			</select>
+			<?php submit_button( __( 'Filter', 'pmpro-approvals' ), '', 'filter_action', false ); ?>
 		</div>
-	
+		<?php if ( $approval_users ) { ?>
+		<div class="tablenav-pages">
+			<span class="displaying-num"><?php echo esc_html( sprintf( _n( '1 item', '%s items', $totalrows, 'pmpro-approvals' ), number_format_i18n( $totalrows ) ) ); ?></span>
+		</div>
+		<?php } ?>
+	</div>
+
+	<?php if ( $approval_users ) { ?>
 		<table class="widefat striped pmpro_responsive_table">
 			<thead>
 				<tr class="thead">
@@ -160,7 +162,7 @@ if ( ! empty( $_REQUEST['approve'] ) ) {
 					$user_data = get_userdata( $approval_user->ID );
 					?>
 					<tr>
-						<td data-colname="<?php esc_attr_e( 'ID', 'pmpro-approvals' ); ?>"><?php echo $user_data->ID; ?></td>
+						<td data-colname="<?php esc_attr_e( 'ID', 'pmpro-approvals' ); ?>"><?php echo intval( $user_data->ID ); ?></td>
 						<td class="username column-username has-row-actions" data-colname="<?php esc_attr_e( 'Applicant', 'pmpro-approvals' ); ?>">
 							<?php echo get_avatar( $user_data->ID, 32 ); ?>								
 							<?php
@@ -215,12 +217,12 @@ if ( ! empty( $_REQUEST['approve'] ) ) {
 								 * Filter the extra actions for this user in the approvals list table.
 								 *
 								 * @param array  $actions  The list of actions.
-								 * @param object $template  The user data for this row.
+								 * @param object $user_data  The user data for this row.
 								 * @param object $approval_user  The approval user data for this row.
 								 */
 								$actions = apply_filters( 'pmpro_approvals_user_row_actions', $actions, $user_data, $approval_user );
 
-								$actions_html = [];
+								$actions_html = array();
 							?>
 							<div class="row-actions">
 								<?php
@@ -242,7 +244,7 @@ if ( ! empty( $_REQUEST['approve'] ) ) {
 						</td>
 						<?php do_action( 'pmpro_approvals_list_extra_cols_body', $user_data ); ?>						
 						<td data-colname="<?php esc_attr_e( 'Membership', 'pmpro-approvals' ); ?>">
-							<?php echo $approval_user->membership; ?>
+							<?php echo esc_html( $approval_user->membership ); ?>
 						</td>						
 						<td data-colname="<?php esc_attr_e( 'Approval Status', 'pmpro-approvals' ); ?>">										
 							<?php

--- a/adminpages/userinfo.php
+++ b/adminpages/userinfo.php
@@ -1,9 +1,9 @@
 <?php
-	global $wpdb, $current_user;
+	global $wpdb, $current_user, $pmpro_user_fields;
 
 	//only admins can get this
 if ( ! function_exists( 'current_user_can' ) || ! current_user_can( 'pmpro_approvals' ) ) {
-	die( 'You do not have permission to perform this action.' );
+	wp_die( __( 'You do not have permissions to perform this action.', 'pmpro-approvals' ) );
 }
 
 if ( isset( $_REQUEST['l'] ) ) {
@@ -18,14 +18,6 @@ if ( isset( $_REQUEST['l'] ) ) {
 	}
 }
 
-if ( ! empty( $_REQUEST['approve'] ) ) {
-	PMPro_Approvals::approveMember( intval( $_REQUEST['approve'] ), $l );
-} elseif ( ! empty( $_REQUEST['deny'] ) ) {
-	PMPro_Approvals::denyMember( intval( $_REQUEST['deny'] ), $l );
-} elseif ( ! empty( $_REQUEST['unapprove'] ) ) {
-	PMPro_Approvals::resetMember( intval( $_REQUEST['unapprove'] ), $l );
-}
-
 	//get the user
 if ( empty( $_REQUEST['user_id'] ) ) {
 	wp_die( __( 'No user id passed in.', 'pmpro-approvals' ) );
@@ -37,136 +29,231 @@ if ( empty( $_REQUEST['user_id'] ) ) {
 		wp_die( sprintf( __( 'No user found with ID %d.', 'pmpro-approvals' ), intval( $_REQUEST['user_id'] ) ) );
 	}
 }
+
+	//process approve/deny/reset actions. The action methods set the global $msg/$msgt
+	//that admin_header.php prints; on success, override $msgt to personalize it with the
+	//member's name. On failure the methods set their own error message, so leave it alone.
+	global $msg, $msgt;
+if ( ! empty( $_REQUEST['approve'] ) ) {
+	check_admin_referer( 'pmpro_approvals', 'pmpro_approvals_nonce' );
+	if ( PMPro_Approvals::approveMember( intval( $_REQUEST['approve'] ), $l ) ) {
+		/* translators: %s: member display name */
+		$msgt = sprintf( __( '%s has been approved.', 'pmpro-approvals' ), $user->display_name );
+	}
+} elseif ( ! empty( $_REQUEST['deny'] ) ) {
+	check_admin_referer( 'pmpro_approvals', 'pmpro_approvals_nonce' );
+	if ( PMPro_Approvals::denyMember( intval( $_REQUEST['deny'] ), $l ) ) {
+		/* translators: %s: member display name */
+		$msgt = sprintf( __( '%s has been denied.', 'pmpro-approvals' ), $user->display_name );
+	}
+} elseif ( ! empty( $_REQUEST['unapprove'] ) ) {
+	check_admin_referer( 'pmpro_approvals', 'pmpro_approvals_nonce' );
+	if ( PMPro_Approvals::resetMember( intval( $_REQUEST['unapprove'] ), $l ) ) {
+		/* translators: %s: member display name */
+		$msgt = sprintf( __( 'Approval for %s has been reset to pending.', 'pmpro-approvals' ), $user->display_name );
+	}
+}
+
+	//the level this user is being approved for
+	$level_details = pmpro_getSpecificMembershipLevelForUser( $user->ID, $l );
+
+	require_once PMPRO_DIR . '/adminpages/admin_header.php';
 ?>
-<div class="wrap pmpro_admin">	
-	
-	<form id="posts-filter" method="get" action="">	
-	<h2>
-		<?php echo intval( $user->ID ); ?> - <?php echo esc_html( $user->display_name ); ?> (<?php echo esc_html( $user->user_login ); ?>)
-		<a href="<?php echo admin_url( 'user-edit.php?user_id=' . intval( $user->ID ) ); ?>" class="button button-primary"><?php esc_html_e( 'Edit Profile', 'pmpro-approvals' ); ?></a>
-	</h2>	
-	
-	<h3><?php esc_html_e( 'Account Information', 'pmpro-approvals' ); ?></h3>
-	<table class="form-table">
-		<tr>
-			<th><label><?php esc_html_e( 'User ID', 'pmpro-approvals' ); ?></label></th>
-			<td><?php echo intval( $user->ID ); ?></td>
-		</tr>		
-		<tr>
-			<th><label><?php _e( 'Username', 'pmpro-approvals' ); ?></label></th>
-			<td><?php echo esc_html( $user->user_login ); ?></td>
-		</tr>
-		<tr>
-			<th><label><?php _e( 'Email', 'pmpro-approvals' ); ?></label></th>
-			<td><?php echo sanitize_email( $user->user_email ); ?></td>
-		</tr>
-		<tr>
-			<th><label><?php esc_html_e( 'Membership Level', 'pmpro-approvals' ); ?></label></th>
-			<td>
-			<?php
-			//Changed this to show Membership Level Name now, so approvers don't need to go back and forth to see what level the user is applying for.
-			 $level_details = pmpro_getSpecificMembershipLevelForUser( $user->ID, $l );
-
-			 echo esc_html( $level_details->name );
-        
-			?>
-			</td>
-		</tr>
-		<tr>
-			<th><label><?php _e( 'Approval Status', 'pmpro-approvals' ); ?></label></th>
-			<td>
-			<?php
-			//show status here
-			if ( PMPro_Approvals::isApproved( $user->ID, $l ) || PMPro_Approvals::isDenied( $user->ID, $l ) ) {
-				if ( ! PMPro_Approvals::getEmailConfirmation( $user->ID ) ) {
-					_e( 'Email Confirmation Required.', 'pmpro-approvals' );
-				} else {
-					echo PMPro_Approvals::getUserApprovalStatus( $user->ID, $l, false );
-				?>
-				[<a href="javascript:askfirst('Are you sure you want to reset approval for <?php echo esc_attr( $user->user_login ); ?>?', '?page=pmpro-approvals&user_id=<?php echo esc_attr( $user->ID ); ?>&unapprove=<?php echo esc_attr( $user->ID ); ?>&l=<?php echo esc_attr( $l ) ?>');">X</a>]
+<hr class="wp-header-end" />
+<nav class="pmpro-nav-secondary pmpro-breadcrumbs" aria-labelledby="pmpro-approvals-breadcrumbs">
+	<h2 id="pmpro-approvals-breadcrumbs" class="screen-reader-text"><?php esc_html_e( 'Approvals navigation', 'pmpro-approvals' ); ?></h2>
+	<ul>
+		<li>
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-approvals' ) ); ?>" title="<?php esc_attr_e( 'View All Approvals', 'pmpro-approvals' ); ?>">
+				<?php esc_html_e( 'Approvals', 'pmpro-approvals' ); ?>
+			</a>
+		</li>
+		<li>
+			<span class="current" aria-current="page">
 				<?php
-				}   // end of email confirmation check.
-			} else {
-			?>
-													
-			<a href="?page=pmpro-approvals&user_id=<?php echo esc_attr( $user->ID ); ?>&approve=<?php echo esc_attr( $user->ID ); ?>&l=<?php echo esc_attr( $l ) ?>"><?php esc_html_e( 'Approve', 'pmpro-approvals' ); ?></a> |
-			<a href="?page=pmpro-approvals&user_id=<?php echo esc_attr( $user->ID ); ?>&deny=<?php echo esc_attr( $user->ID ); ?>&l=<?php echo esc_attr( $l ) ?>"><?php esc_html_e( 'Deny', 'pmpro-approvals' ); ?></a>
-			<?php
-			}
-			?>
-			</td>
-		</tr>
-	</table>
-	
-	<?php
-		if ( function_exists( 'pmpro_get_user_fields_for_profile' ) ) {
-			global $pmpro_user_fields, $pmprorh_checkout_boxes;
+					/* translators: 1: member display name, 2: user ID */
+					echo esc_html( sprintf( __( '%1$s (ID #%2$d)', 'pmpro-approvals' ), $user->display_name, $user->ID ) );
+				?>
+			</span>
+		</li>
+	</ul>
+</nav>
 
-			//show the fields
-			if ( ! empty( $pmpro_user_fields ) ) {
-				foreach ( $pmpro_user_fields as $where => $fields ) {
-					$box = pmpro_get_field_group_by_name( $where );
-					?>
-					<?php if ( isset( $box->label ) ) { ?>
-						<h3><?php echo esc_html( $box->label ); ?></h3>
-					<?php } ?>
+<h1><?php echo esc_html( sprintf( __( 'Application for %s', 'pmpro-approvals' ), $user->display_name ) ); ?></h1>
 
-					<table class="form-table">
-					<?php
-					//cycle through groups
+<div class="pmpro_two_col pmpro_two_col-right">
 
-					foreach ( $fields as $field ) {
-						// show field as long as it's not false
-						if ( false != $field->profile ) {
-
-						// Check to see if level is set for the field.
-						if ( ! empty( $field->levels ) && ! in_array( $level_details->ID, $field->levels ) ) {
-							continue;
-						}
-							
-						?>
-						<tr>
-							<th><label><?php echo esc_attr( $field->label ); ?></label></th>
+	<div class="pmpro_main">
+		<div class="pmpro_section" data-visibility="shown" data-activated="true">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
+					<span class="dashicons dashicons-arrow-up-alt2"></span>
+					<?php esc_html_e( 'Application Information', 'pmpro-approvals' ); ?>
+				</button>
+			</div>
+			<div class="pmpro_section_inside">
+				<table class="form-table">
+					<tr>
+						<th scope="row"><label><?php esc_html_e( 'Membership Level', 'pmpro-approvals' ); ?></label></th>
+						<td><?php echo ! empty( $level_details ) ? esc_html( $level_details->name ) : esc_html__( '&#8212;', 'pmpro-approvals' ); ?></td>
+					</tr>
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Approval Status', 'pmpro-approvals' ); ?></th>
+						<td>
 							<?php
-							if ( is_array( get_user_meta( $user->ID, $field->name, true ) ) && 'file' === $field->type ) {
-								$field = get_user_meta( $user->ID, $field->name, true );
-								?>
+								$pmpro_approvals_nonce = wp_create_nonce( 'pmpro_approvals' );
+								$action_base           = add_query_arg(
+									array(
+										'page'                  => 'pmpro-approvals',
+										'user_id'               => (int) $user->ID,
+										'l'                     => (int) $l,
+										'pmpro_approvals_nonce' => $pmpro_approvals_nonce,
+									),
+									admin_url( 'admin.php' )
+								);
 
-								<td><a href="<?php echo esc_url( $field['fullurl'] ); ?>" target="_blank" rel="noopener noreferrer"><?php _e( 'View File', 'pmpro-approvals' ); ?></a> (<?php echo esc_attr( $field['filename'] ); ?>)</td>
-
-
-							<?php } else { 
-								$user_field = get_user_meta( $user->ID, $field->name, true );
-
-								// Get all array option values and break up the array into readable content.
-								if ( is_array( $user_field ) ) {
-									 $user_field_string = '';
-									 foreach( $user_field as $key => $value ) {
-										$user_field_string .= $value . ', ';
-									}
-
-									// remove trailing comma from string.
-									echo '<td>' . esc_html( rtrim( $user_field_string, ', ' ) ) . '</td>';
+								if ( PMPro_Approvals::isApproved( $user->ID, $l ) || PMPro_Approvals::isDenied( $user->ID, $l ) ) { ?>
+									<p><?php echo wp_kses_post( PMPro_Approvals::getUserApprovalStatus( $user->ID, $l, false ) ); ?></p>
+									<p>
+										<a href="javascript:askfirst('<?php echo esc_js( sprintf( __( 'Are you sure you want to reset approval for %s?', 'pmpro-approvals' ), $user->user_login ) ); ?>', '<?php echo esc_js( add_query_arg( 'unapprove', (int) $user->ID, $action_base ) ); ?>');" class="button button-secondary pmpro-has-icon pmpro-has-icon-image-rotate">
+											<?php esc_html_e( 'Reset Approval', 'pmpro-approvals' ); ?>
+										</a>
+									</p>
+									<?php
 								} else {
-									// If Register Helper field is a valid URL, then let's make it clickable.
-									if ( wp_http_validate_url( $user_field ) ) {
-										echo '<td><a href="' . esc_url_raw( $user_field ) . '" target="_blank">' . esc_url( $user_field ) . '</a></td>';
-									} else {
-										echo '<td>' . esc_html( $user_field ) . '</td>';
-									}
+									?>
+									<p><?php echo wp_kses_post( PMPro_Approvals::getUserApprovalStatus( $user->ID, $l, false ) ); ?></p>
+									<p>
+										<a href="<?php echo esc_url( add_query_arg( 'approve', (int) $user->ID, $action_base ) ); ?>" class="button button-primary pmpro-has-icon pmpro-has-icon-yes">
+											<?php esc_html_e( 'Approve', 'pmpro-approvals' ); ?>
+										</a>
+										<a href="<?php echo esc_url( add_query_arg( 'deny', (int) $user->ID, $action_base ) ); ?>" class="button is-destructive pmpro-has-icon pmpro-has-icon-no">
+											<?php esc_html_e( 'Deny', 'pmpro-approvals' ); ?>
+										</a>
+									</p>
+									<?php
 								}
-							
- 							} ?>
+							?>
+						</td>
+					</tr>
+					<?php if ( function_exists( 'pmproec_load_plugin_text_domain' ) ) { ?>
+						<tr>
+							<th scope="row"><?php esc_html_e( 'Email Confirmation', 'pmpro-approvals' ); ?></th>
+							<td>
+								<?php if ( PMPro_Approvals::getEmailConfirmation( $user->ID ) ) { ?>
+									<span class="pmpro_tag pmpro_tag-success"><?php esc_html_e( 'Confirmed', 'pmpro-approvals' ); ?></span>
+								<?php } else { ?>
+									<span class="pmpro_tag pmpro_tag-alert"><?php esc_html_e( 'Not Confirmed', 'pmpro-approvals' ); ?></span>
+									<p class="description"><?php esc_html_e( 'This user has not confirmed their email address. Membership access may be restricted.', 'pmpro-approvals' ); ?></p>
+								<?php } ?>
+							</td>
 						</tr>
-						<?php
-						}   //endif
+					<?php } ?>
+				</table>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end pmpro_section -->
+
+		<?php
+			// Show the user field groups read-only, using core's field value display.
+		if ( function_exists( 'pmpro_get_user_fields_for_profile' ) && ! empty( $pmpro_user_fields ) ) {
+			foreach ( $pmpro_user_fields as $where => $fields ) {
+				$box = pmpro_get_field_group_by_name( $where );
+
+				// Build the read-only rows first so we can skip empty groups.
+				$fields_html = '';
+				foreach ( $fields as $field ) {
+					// Show field as long as it's not false.
+					if ( false == $field->profile ) {
+						continue;
 					}
-					?>
-					</table>
-					<?php
+
+					// Check to see if level is set for the field.
+					if ( ! empty( $field->levels ) && ! empty( $level_details ) && ! in_array( $level_details->ID, $field->levels ) ) {
+						continue;
+					}
+
+					// Resolve the stored value the same way PMPro core does.
+					$meta_key = ! empty( $field->meta_key ) ? $field->meta_key : $field->name;
+					if ( metadata_exists( 'user', $user->ID, $meta_key ) ) {
+						$value = get_user_meta( $user->ID, $meta_key, true );
+					} elseif ( isset( $field->value ) ) {
+						$value = $field->value;
+					} else {
+						$value = '';
+					}
+
+					// displayValue() returns the value rendered read-only (already escaped via wp_kses).
+					$fields_html .= '<tr><th scope="row"><label>' . esc_html( $field->label ) . '</label></th><td>' . $field->displayValue( $value, false ) . '</td></tr>';
 				}
+
+				if ( empty( $fields_html ) ) {
+					continue;
+				}
+				?>
+				<div class="pmpro_section" data-visibility="shown" data-activated="true">
+					<div class="pmpro_section_toggle">
+						<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
+							<span class="dashicons dashicons-arrow-up-alt2"></span>
+							<?php echo esc_html( isset( $box->label ) ? $box->label : '' ); ?>
+						</button>
+					</div>
+					<div class="pmpro_section_inside">
+						<table class="form-table">
+							<?php echo $fields_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						</table>
+					</div> <!-- end pmpro_section_inside -->
+				</div> <!-- end pmpro_section -->
+				<?php
 			}
 		}
-	?>
-	<a href="?page=pmpro-approvals" class="">&laquo; <?php esc_html_e( 'Back to Approvals', 'pmpro-approvals' ); ?></a>
-</div>
+		?>
+	</div> <!-- end pmpro_main -->
+
+	<div class="pmpro_sidebar">
+		<div class="pmpro_section" data-visibility="shown" data-activated="true">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
+					<span class="dashicons dashicons-arrow-up-alt2"></span>
+					<?php esc_html_e( 'Member Information', 'pmpro-approvals' ); ?>
+				</button>
+			</div>
+			<div class="pmpro_section_inside">
+				<div class="pmpro_member-box">
+					<div class="pmpro_member-box-avatar">
+						<?php echo get_avatar( (int) $user->ID, 64 ); ?>
+					</div>
+					<div class="pmpro_member-box-info">
+						<h2><strong><?php echo esc_html( $user->display_name ); ?></strong></h2>
+						<div class="pmpro_member-box-actions">
+							<?php
+								$member_actions = array();
+								if ( function_exists( 'pmpro_member_edit_get_panels' ) ) {
+									$member_actions['edit_member'] = sprintf(
+										'<a href="%1$s">%2$s</a>',
+										esc_url( add_query_arg( array( 'page' => 'pmpro-member', 'user_id' => (int) $user->ID ), admin_url( 'admin.php' ) ) ),
+										esc_html__( 'Edit Member', 'pmpro-approvals' )
+									);
+								}
+								$member_actions['edit_user'] = sprintf(
+									'<a href="%1$s">%2$s</a>',
+									esc_url( add_query_arg( array( 'user_id' => (int) $user->ID ), admin_url( 'user-edit.php' ) ) ),
+									esc_html__( 'Edit User', 'pmpro-approvals' )
+								);
+								$member_actions_html = array();
+								foreach ( $member_actions as $class => $link_html ) {
+									$member_actions_html[] = sprintf( '<span class="%1$s">%2$s</span>', esc_attr( $class ), $link_html );
+								}
+								echo implode( ' | ', $member_actions_html ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							?>
+						</div>
+					</div>
+				</div>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end pmpro_section -->
+
+	</div> <!-- end pmpro_sidebar -->
+
+</div> <!-- end pmpro_two_col -->
+
+<?php
+	require_once PMPRO_DIR . '/adminpages/admin_footer.php';

--- a/classes/class-pmpro-approvals-member-edit-panel.php
+++ b/classes/class-pmpro-approvals-member-edit-panel.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * "Approvals" panel for the PMPro Member Edit screen (admin.php?page=pmpro-member).
+ *
+ * Shows the member's membership applications (one row per approval-required level)
+ * and their full approval history log.
+ *
+ * @since TBD
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+class PMPro_Approvals_Member_Edit_Panel extends PMPro_Member_Edit_Panel {
+
+	/**
+	 * @since TBD
+	 */
+	public function __construct() {
+		$this->slug  = 'approvals';
+		$this->title = __( 'Approvals', 'pmpro-approvals' );
+	}
+
+	/**
+	 * Only show the panel when the current user can edit members and at least
+	 * one membership level requires approval.
+	 *
+	 * @since TBD
+	 */
+	public function should_show() {
+		if ( ! function_exists( 'pmpro_get_edit_member_capability' ) || ! current_user_can( pmpro_get_edit_member_capability() ) ) {
+			return false;
+		}
+
+		$approval_levels = PMPro_Approvals::getApprovalLevels();
+		return ! empty( $approval_levels );
+	}
+
+	/**
+	 * @since TBD
+	 */
+	protected function display_panel_contents() {
+		$user = self::get_user();
+		if ( empty( $user->ID ) ) {
+			return;
+		}
+
+		// Collect the levels this member has an application for: either a recorded
+		// approval decision or a level they currently hold that requires approval.
+		$application_level_ids = array();
+		foreach ( PMPro_Approvals::getApprovalLevels() as $approval_level_id ) {
+			$stored    = get_user_meta( $user->ID, 'pmpro_approval_' . $approval_level_id, true );
+			$has_level = PMPro_Approvals::hasMembershipLevelSansApproval( $approval_level_id, $user->ID );
+			if ( ! empty( $stored ) || $has_level ) {
+				$application_level_ids[] = $approval_level_id;
+			}
+		}
+
+		$email_confirmation_active = function_exists( 'pmproec_load_plugin_text_domain' );
+		?>
+		<h3><?php esc_html_e( 'Applications', 'pmpro-approvals' ); ?></h3>
+		<?php if ( empty( $application_level_ids ) ) { ?>
+			<p><?php esc_html_e( 'This member has no membership applications requiring approval.', 'pmpro-approvals' ); ?></p>
+		<?php } else { ?>
+			<table class="widefat striped pmpro_responsive_table">
+				<thead>
+					<tr>
+						<th><?php esc_html_e( 'Membership Level', 'pmpro-approvals' ); ?></th>
+						<th><?php esc_html_e( 'Approval Status', 'pmpro-approvals' ); ?></th>
+						<?php if ( $email_confirmation_active ) { ?>
+							<th><?php esc_html_e( 'Email Confirmation', 'pmpro-approvals' ); ?></th>
+						<?php } ?>
+						<th><?php esc_html_e( 'Actions', 'pmpro-approvals' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php
+					foreach ( $application_level_ids as $application_level_id ) {
+						$level      = pmpro_getLevel( $application_level_id );
+						/* translators: %d: membership level ID */
+						$level_name = ! empty( $level->name ) ? $level->name : sprintf( __( 'Level #%d', 'pmpro-approvals' ), $application_level_id );
+
+						if ( PMPro_Approvals::isApproved( $user->ID, $application_level_id ) ) {
+							$badge_class = 'pmpro_tag-success';
+							$badge_label = __( 'Approved', 'pmpro-approvals' );
+						} elseif ( PMPro_Approvals::isDenied( $user->ID, $application_level_id ) ) {
+							$badge_class = 'pmpro_tag-error';
+							$badge_label = __( 'Denied', 'pmpro-approvals' );
+						} else {
+							$badge_class = 'pmpro_tag-alert';
+							$badge_label = __( 'Pending', 'pmpro-approvals' );
+						}
+
+						$view_url = add_query_arg(
+							array(
+								'page'    => 'pmpro-approvals',
+								'user_id' => (int) $user->ID,
+								'l'       => (int) $application_level_id,
+							),
+							admin_url( 'admin.php' )
+						);
+						?>
+						<tr>
+							<td data-colname="<?php esc_attr_e( 'Membership Level', 'pmpro-approvals' ); ?>"><?php echo esc_html( $level_name ); ?></td>
+							<td data-colname="<?php esc_attr_e( 'Approval Status', 'pmpro-approvals' ); ?>"><span class="pmpro_tag <?php echo esc_attr( $badge_class ); ?>"><?php echo esc_html( $badge_label ); ?></span></td>
+							<?php if ( $email_confirmation_active ) { ?>
+								<td data-colname="<?php esc_attr_e( 'Email Confirmation', 'pmpro-approvals' ); ?>">
+									<?php if ( PMPro_Approvals::getEmailConfirmation( $user->ID ) ) { ?>
+										<span class="pmpro_tag pmpro_tag-success"><?php esc_html_e( 'Confirmed', 'pmpro-approvals' ); ?></span>
+									<?php } else { ?>
+										<span class="pmpro_tag pmpro_tag-alert"><?php esc_html_e( 'Not Confirmed', 'pmpro-approvals' ); ?></span>
+									<?php } ?>
+								</td>
+							<?php } ?>
+							<td data-colname="<?php esc_attr_e( 'Actions', 'pmpro-approvals' ); ?>"><a href="<?php echo esc_url( $view_url ); ?>"><?php esc_html_e( 'View Application', 'pmpro-approvals' ); ?></a></td>
+						</tr>
+						<?php
+					}
+					?>
+				</tbody>
+			</table>
+		<?php } ?>
+
+		<h3><?php esc_html_e( 'Approval History', 'pmpro-approvals' ); ?></h3>
+		<?php
+			// showUserLog() returns escaped markup for the per-user approval history.
+			echo PMPro_Approvals::showUserLog( $user->ID ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		?>
+		<?php
+	}
+}

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -88,9 +88,6 @@ class PMPro_Approvals {
 		add_action( 'admin_bar_menu', array( 'PMPro_Approvals', 'admin_bar_menu' ), 1000 );
 		add_action( 'admin_init', array( 'PMPro_Approvals', 'admin_init' ) );
 
-		//add user actions to the approvals page
-		add_filter( 'pmpro_approvals_user_row_actions', array( 'PMPro_Approvals', 'pmpro_approvals_user_row_actions' ), 10, 3 );
-
 		//add approval section to edit user page
 		$membership_level_capability = apply_filters( 'pmpro_edit_member_capability', 'manage_options' );
 		if ( current_user_can( $membership_level_capability ) ) {
@@ -102,11 +99,18 @@ class PMPro_Approvals {
 			add_action( 'show_user_profile', array( 'PMPro_Approvals', 'show_user_profile_status' ) );
 		}
 
+		//add the Approvals panel to the PMPro Member Edit screen (admin.php?page=pmpro-member)
+		add_filter( 'pmpro_member_edit_panels', array( 'PMPro_Approvals', 'add_member_edit_panel' ) );
+
 		//check approval status at checkout
 		add_action( 'pmpro_checkout_preheader', array( 'PMPro_Approvals', 'pmpro_checkout_preheader' ) );
 
 		//add approval status to members list
 		add_action( 'pmpro_members_list_user', array( 'PMPro_Approvals', 'pmpro_members_list_user' ) );
+
+		//add an Email Confirmation column to the approvals list (only when the Email Confirmation Add On is active)
+		add_action( 'pmpro_approvals_list_extra_cols_header', array( 'PMPro_Approvals', 'email_confirmation_column_header' ) );
+		add_action( 'pmpro_approvals_list_extra_cols_body', array( 'PMPro_Approvals', 'email_confirmation_column_body' ) );
 
 		//filter to add the approval membership level template
 		add_filter( 'pmpro_membershiplevels_template_level', array( 'PMPro_Approvals', 'pmpro_membershiplevels_template_level' ), 10, 2 );
@@ -127,7 +131,8 @@ class PMPro_Approvals {
 		add_filter( 'pmpro_no_access_message_header', array( 'PMPro_Approvals', 'pmpro_no_access_message_header' ) ); // PMPro v3.1+.
 		add_filter( 'pmpro_no_access_message_body', array( 'PMPro_Approvals', 'pmpro_non_member_text_filter' ) ); // PMPro v3.1+.
 		add_filter( 'pmpro_non_member_text_filter', array( 'PMPro_Approvals', 'pmpro_non_member_text_filter' ) ); // Pre-PMPro 3.1
-		add_action( 'pmpro_account_bullets_top', array( 'PMPro_Approvals', 'pmpro_account_bullets_top' ) );
+		// Show approval status on the account page per-level-card.
+		add_action( 'pmpro_membership_account_after_level_card_content', array( 'PMPro_Approvals', 'pmpro_account_membership_level_status' ), 10, 1 );
 		add_filter( 'pmpro_confirmation_message', array( 'PMPro_Approvals', 'pmpro_confirmation_message' ), 10, 2 );
 		add_action( 'pmpro_before_change_membership_level', array( 'PMPro_Approvals', 'pmpro_before_change_membership_level' ), 10, 4 );
 		add_action( 'pmpro_after_change_membership_level', array( 'PMPro_Approvals', 'pmpro_after_change_membership_level' ), 10, 2 );
@@ -721,15 +726,24 @@ class PMPro_Approvals {
 				}
 			}
 
-			//if we have a level, check if it requires approval and if so check user meta
-			if ( ! empty( $level_id ) && self::hasMembershipLevelSansApproval( $level_id, $user_id ) ) {
-				//if the level doesn't require approval, then the user is approved
+			//if we have a level, surface the recorded approval decision
+			if ( ! empty( $level_id ) ) {
 				if ( ! self::requiresApproval( $level_id ) ) {
-					//approval not required, so return status approved
-					$user_approval = array( 'status' => 'approved' );
+					//approval not required; treat as approved if they actually hold the level
+					if ( self::hasMembershipLevelSansApproval( $level_id, $user_id ) ) {
+						$user_approval = array( 'status' => 'approved' );
+					}
 				} else {
-					//approval required, check user meta
+					//approval required. Surface the admin's recorded decision regardless of whether
+					//the member currently has access to the level (e.g. while email confirmation is
+					//still pending). Access to the level is enforced separately by the membership filters.
 					$user_approval = get_user_meta( $user_id, 'pmpro_approval_' . $level_id, true );
+
+					//no decision recorded yet, but they already hold the level (e.g. were granted it
+					//before approval was required), so treat them as approved
+					if ( ( empty( $user_approval ) || ! is_array( $user_approval ) ) && self::hasMembershipLevelSansApproval( $level_id, $user_id ) ) {
+						$user_approval = array( 'status' => 'approved' );
+					}
 				}
 			}
 		}
@@ -1405,52 +1419,36 @@ class PMPro_Approvals {
 	}
 
 	/**
-	 * Set user action links for approvals page
+	 * Add Approvals status to a level card on the Account Page. (PMPro 3.4+)
+	 *
+	 * @param object $level The membership level for the card being rendered.
 	 */
-	public static function pmpro_approvals_user_row_actions( $actions, $user, $approval_user = null ) {
-		if ( empty( $approval_user ) ) {
-			// Doing it wrong. Approval user should now be passed.
-			_doing_it_wrong( __FUNCTION__, 'The $approval_user parameter is required.', '1.5' );
+	public static function pmpro_account_membership_level_status( $level ) {
+		// Only levels that require approval have a status to show.
+		if ( empty( $level ) || ! self::requiresApproval( $level->ID ) ) {
+			return;
 		}
 
-		$cap = apply_filters( 'pmpro_approvals_cap', 'pmpro_approvals' );
-
-		if ( current_user_can( 'edit_users' ) && ! empty( $user->ID ) ) {
-			$actions[] = '<a href="' . admin_url( 'user-edit.php?user_id=' . $user->ID ) . '">Edit</a>';
+		// Only show the status if it's pending or denied. Approved is the default and doesn't need to be shown.
+		if ( self::isDenied( null, $level->ID ) ) {
+			$status_class = 'pmpro_tag-error';
+			$status_label = __( 'Denied', 'pmpro-approvals' );
+		} elseif ( self::isPending( null, $level->ID ) ) {
+			$status_class = 'pmpro_tag-alert';
+			$status_label = __( 'Pending', 'pmpro-approvals' );
+		} else {
+			// Approved (or no status to show).
+			return;
 		}
 
-		if ( current_user_can( $cap ) && ! empty( $user->ID ) ) {
-			if ( empty( $approval_user ) ) {
-				$actions[] = '<a href="' . admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $user->ID ) . '">View</a>';
-			} else {
-				$actions[] = '<a href="' . admin_url( 'admin.php?page=pmpro-approvals&user_id=' . $user->ID . '&l=' . $approval_user->membership_id ) . '">View</a>';
-			}
-		}
-
-		return $actions;
-	}
-
-	/**
-	 * Add Approvals status to Account Page.
-	 */
-	public static function pmpro_account_bullets_top() {
-		// Get all of the user's approval statuses.
-		$approval_statuses = self::getUserApprovalStatuses();
-
-		// Get all levels that require approval.
-		$approval_levels = self::getApprovalLevels();
-
-		// Display approval status for each level that requires approval.
-		foreach ( $approval_levels as $approval_level_id ) {
-			// Check if we have an approval status.
-			if ( ! empty( $approval_statuses[ $approval_level_id ] ) ) {
-				// Check that the user has this level.
-				if ( self::hasMembershipLevelSansApproval( $approval_level_id ) ) {
-					$level = pmpro_getLevel( $approval_level_id );
-					printf( '<li class="' . esc_attr( pmpro_get_element_class( 'pmpro_list_item' ) ) . '"><strong>' . esc_html__( 'Approval Status for %s', 'pmpro-approvals' ) . ':' . '</strong> %s</li>', $level->name, $approval_statuses[ $approval_level_id ] );
-				}
-			}
-		}
+		echo '<p class="pmpro_account-membership-approval">';
+		echo '<span class="pmpro_tag ' . esc_attr( $status_class ) . '">';
+		printf(
+			/* translators: %s: Membership approval status, e.g. Pending or Denied */
+			esc_html__( '%s Approval', 'pmpro-approvals' ),
+			esc_html( $status_label )
+		);
+		echo '</span></p>';
 	}
 
 	/**
@@ -1679,8 +1677,70 @@ class PMPro_Approvals {
 		return $email;
 	}
 
+	/**
+	 * Output the Email Confirmation column header on the approvals list.
+	 * Only shown when the Email Confirmation Add On is active.
+	 *
+	 * @since TBD
+	 */
+	public static function email_confirmation_column_header( $approval_users = null ) {
+		if ( ! function_exists( 'pmproec_load_plugin_text_domain' ) ) {
+			return;
+		}
+		echo '<th>' . esc_html__( 'Email Confirmation', 'pmpro-approvals' ) . '</th>';
+	}
+
+	/**
+	 * Output the Email Confirmation column cell on the approvals list.
+	 * Only shown when the Email Confirmation Add On is active.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_User $user_data The user for this row.
+	 */
+	public static function email_confirmation_column_body( $user_data ) {
+		if ( ! function_exists( 'pmproec_load_plugin_text_domain' ) ) {
+			return;
+		}
+
+		echo '<td data-colname="' . esc_attr__( 'Email Confirmation', 'pmpro-approvals' ) . '">';
+
+		if ( self::getEmailConfirmation( $user_data->ID ) ) {
+			echo '<span class="pmpro_tag pmpro_tag-success">' . esc_html__( 'Confirmed', 'pmpro-approvals' ) . '</span>';
+		} else {
+			echo '<span class="pmpro_tag pmpro_tag-alert">' . esc_html__( 'Not Confirmed', 'pmpro-approvals' ) . '</span>';
+		}
+
+		echo '</td>';
+	}
+
+	/**
+	 * Register the Approvals panel on the PMPro Member Edit screen.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $panels The member edit panels.
+	 * @return array
+	 */
+	public static function add_member_edit_panel( $panels ) {
+		if ( ! class_exists( 'PMPro_Member_Edit_Panel' ) ) {
+			return $panels;
+		}
+
+		require_once dirname( __FILE__ ) . '/classes/class-pmpro-approvals-member-edit-panel.php';
+		$panels[] = new PMPro_Approvals_Member_Edit_Panel();
+
+		return $panels;
+	}
+
 	//Approve members from edit profile in WordPress.
 	public static function show_user_profile_status( $user ) {
+		// The PMPro Member Edit screen shows the dedicated Approvals panel instead, so
+		// don't duplicate the approval information in the user-info panel there.
+		if ( ! empty( $_REQUEST['page'] ) && 'pmpro-member' === sanitize_key( wp_unslash( $_REQUEST['page'] ) ) ) {
+			return;
+		}
+
 		//show info
 		?>
 		<table id="pmpro_approvals_status_table" class="form-table">
@@ -1688,12 +1748,52 @@ class PMPro_Approvals {
 				<th><?php esc_html_e( 'Approval Statuses', 'pmpro-approvals' ); ?></th>
 				<td>
 					<?php
-					// Link to the approvals admin page for this user.
-					$approvals_admin_url = admin_url( 'admin.php?page=pmpro-approvals&s=' . $user->display_name . '&status=all' );
+					// Build a direct link to each approval application (user + level) the member has.
+					$application_links = array();
+					$user_levels       = pmpro_getMembershipLevelsForUser( $user->ID );
+					if ( ! empty( $user_levels ) ) {
+						foreach ( $user_levels as $user_level ) {
+							if ( ! self::requiresApproval( $user_level->id ) ) {
+								continue;
+							}
+							$view_url = add_query_arg(
+								array(
+									'page'    => 'pmpro-approvals',
+									'user_id' => (int) $user->ID,
+									'l'       => (int) $user_level->id,
+								),
+								admin_url( 'admin.php' )
+							);
+							$application_links[] = sprintf(
+								'<a href="%1$s">%2$s</a>',
+								esc_url( $view_url ),
+								/* translators: %s: membership level name */
+								esc_html( sprintf( __( 'View %s Application', 'pmpro-approvals' ), $user_level->name ) )
+							);
+						}
+					}
+
+					if ( ! empty( $application_links ) ) {
+						foreach ( $application_links as $application_link ) {
+							echo '<p>' . $application_link . '</p>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						}
+					} else {
+						// No approval-required levels for this member; link to the full approvals list filtered to them.
+						$approvals_admin_url = add_query_arg(
+							array(
+								'page'   => 'pmpro-approvals',
+								's'      => $user->display_name,
+								'status' => 'all',
+							),
+							admin_url( 'admin.php' )
+						);
+						?>
+						<p>
+							<a href="<?php echo esc_url( $approvals_admin_url ); ?>"><?php esc_html_e( 'Manage Approval Statuses', 'pmpro-approvals' ); ?></a>
+						</p>
+						<?php
+					}
 					?>
-					<p>
-						<a href="<?php echo esc_url( $approvals_admin_url ); ?>"><?php esc_html_e( 'Manage Approval Statuses', 'pmpro-approvals' ); ?></a>
-					</p>
 				</td>
 			</tr>
 			<?php
@@ -1775,7 +1875,19 @@ class PMPro_Approvals {
 			$data = array();
 		}
 
-		$data[] = $users_approval_information['status'] . ' by ' . $users_approval_information['approver'] . ' on ' . date_i18n( get_option( 'date_format' ), $users_approval_information['timestamp'] );
+		// Include the membership level that was handled in the log entry.
+		$level      = pmpro_getLevel( $level_id );
+		/* translators: %d: membership level ID */
+		$level_name = ! empty( $level->name ) ? $level->name : sprintf( __( 'level #%d', 'pmpro-approvals' ), $level_id );
+
+		$data[] = sprintf(
+			/* translators: 1: approval status, 2: membership level name, 3: approver login, 4: date */
+			__( '%1$s for %2$s by %3$s on %4$s', 'pmpro-approvals' ),
+			$users_approval_information['status'],
+			$level_name,
+			$users_approval_information['approver'],
+			date_i18n( get_option( 'date_format' ), $users_approval_information['timestamp'] )
+		);
 
 		update_user_meta( $user_id, 'pmpro_approval_log', $data );
 
@@ -1795,15 +1907,15 @@ class PMPro_Approvals {
 			$user_id = $current_user->ID;
 		}
 
-		//create a variable to generate the unordered list and populate according to meta.
-		$generated_list = '<ul id="pmpro-approvals-log">';
-
-		//Get the approval log array meta.
+		// Get the approval log array meta.
 		$approval_log_meta = get_user_meta( $user_id, 'pmpro_approval_log', true );
 
 		if ( ! empty( $approval_log_meta ) ) {
 
 			$approval_log = array_reverse( $approval_log_meta );
+
+			// Create a variable to generate the unordered list and populate according to meta.
+			$generated_list = '<ul id="pmpro-approvals-log">';
 
 			foreach ( $approval_log as $key => $value ) {
 				$generated_list .= '<li><pre>' . $value . '</pre></li>';
@@ -1857,7 +1969,11 @@ class PMPro_Approvals {
 			$sql_parts = array();
 			$sql_parts['SELECT'] = "SELECT COUNT(mu.user_id) as count FROM $wpdb->pmpro_memberships_users mu ";
 			$sql_parts['JOIN'] = "LEFT JOIN $wpdb->usermeta um ON um.user_id = mu.user_id AND um.meta_key LIKE CONCAT('pmpro_approval_', mu.membership_id) ";
-			$sql_parts['WHERE'] = "WHERE mu.status = 'active' AND mu.membership_id IN (" . implode( ',', $approval_levels ) . ") AND um.meta_value LIKE '%" . esc_sql( $approval_status ) . "%' ";
+			$sql_parts['WHERE'] = "WHERE mu.status = 'active' AND mu.membership_id IN (" . implode( ',', $approval_levels ) . ") ";
+			// 'all' counts every member in an approval-required level, regardless of approval status.
+			if ( 'all' !== $approval_status ) {
+				$sql_parts['WHERE'] .= "AND um.meta_value LIKE '%" . esc_sql( $approval_status ) . "%' ";
+			}
 			$sql_parts['GROUP'] = "";
 			$sql_parts['ORDER'] = "";
 			$sql_parts['LIMIT'] = "";

--- a/pmpro-approvals.php
+++ b/pmpro-approvals.php
@@ -1918,7 +1918,7 @@ class PMPro_Approvals {
 			$generated_list = '<ul id="pmpro-approvals-log">';
 
 			foreach ( $approval_log as $key => $value ) {
-				$generated_list .= '<li><pre>' . $value . '</pre></li>';
+				$generated_list .= '<li><pre>' . esc_html( $value ) . '</pre></li>';
 			}
 
 			$generated_list .= '</ul>';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Modernizes the Approvals admin experience to match current PMPro admin patterns and
makes the per-applicant view far more useful for reviewers.

**Application view (`adminpages/userinfo.php`)**
- Rebuilt into the standard PMPro two-column layout with breadcrumb nav and collapsible sections.
- Application Information section with inline Approve / Deny / Reset Approval buttons, plus an Email Confirmation row when the Email Confirmation Add On is active.
- User field groups rendered read-only via core's `PMPro_Field::displayValue()`, skipping empty groups.
- Member Information sidebar with avatar and Edit Member / Edit User links.
- Approve/deny/reset actions are nonce-protected and show personalized, success-gated admin notices.

**Member Edit panel (new `classes/class-pmpro-approvals-member-edit-panel.php`)**
- Adds an "Approvals" panel to `admin.php?page=pmpro-member` listing the member's applications and full approval history. `show_user_profile_status()` no longer duplicates output there.
- Note - it would be nice for core PMPro to offer hooks on the Memberships panel of the Edit Member screen so we could show something there related to their approval status. I understand that right now we are protective of that panel and limiting how people can hook in.

**Approvals list (`adminpages/approvals.php`)**
- Level + Status dropdown filters (default: All statuses), responsive table, item count, and standard pagination.
- Row hover actions and a colored status badge; merged into a single Applicant column.
- "No members found." notice instead of an empty table.
- No longer bundling/combining status of approval with status of email confirmation.
- Note - this PR changes the default view of the Approvals admin screen to "All". I would be ok reverting this to the "pending" filtered view. All is more in line with how everything else in PMPro behaves. Even showing as "All" here, it would still be sorted by `user_registered` which may (or may not) still show the "new" users first.
- Note - we should consider if showing `user_registered` is the right call on this screen or if we should instead show a column for "Start Date" (which is the date they signed up for this level specifically. Start Date may confuse people though since it isn't really "started" access until approved.

**Core (`pmpro-approvals.php`)**
- Email Confirmation column (active only with the EC Add On).
- Account-page status via `pmpro_membership_account_after_level_card_content`, shown only for Pending/Denied, using boolean status helpers (locale-safe).
- `getUserApproval()` surfaces the recorded decision during restricted access; log entries include the level name; `getApprovalCount()` supports `all`.

### Compatibility
- Account-page approval status uses a hook added in **PMPro 3.4+**. (Consistent with the plugin's existing 3.7+ direction.)
- Email Confirmation column/row only render when the Email Confirmation Add On is active.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
